### PR TITLE
Integrate MinVer for automatic versioning

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -3,7 +3,7 @@ name: Publish NuGet Package
 on:
   push:
     tags:
-      - 'v*'  # Only runs on version tags like v1.0.0
+      - 'v*'  # Only runs on version tags like v1.0.0, v0.1.0-alpha.1
 
 jobs:
   publish:
@@ -13,10 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Extract version from tag
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        with:
+          fetch-depth: 0  # Required for MinVer to access Git history and tags
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -27,10 +25,10 @@ jobs:
         run: dotnet restore DotNetMcp/DotNetMcp.csproj
 
       - name: Build
-        run: dotnet build DotNetMcp/DotNetMcp.csproj --configuration Release --no-restore /p:Version=${{ steps.get_version.outputs.VERSION }}
+        run: dotnet build DotNetMcp/DotNetMcp.csproj --configuration Release --no-restore
 
       - name: Pack
-        run: dotnet pack DotNetMcp/DotNetMcp.csproj --configuration Release --no-build --output ./artifacts /p:Version=${{ steps.get_version.outputs.VERSION }}
+        run: dotnet pack DotNetMcp/DotNetMcp.csproj --configuration Release --no-build --output ./artifacts
 
       - name: Push to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/DotNetMcp/DotNetMcp.csproj
+++ b/DotNetMcp/DotNetMcp.csproj
@@ -18,6 +18,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    
+    <!-- MinVer: Automatic versioning from Git tags -->
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,6 +35,10 @@
     <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="9.0.306" />
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="9.0.306" />
     <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.2" />
+    <PackageReference Include="MinVer" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated the GitHub Actions workflow `publish-nuget.yml` to use MinVer for automatic versioning. This includes adding `fetch-depth` to the `actions/checkout` step and removing manual version extraction. The `dotnet build` and `dotnet pack` commands no longer require explicit version parameters.

In `DotNetMcp.csproj`, added MinVer configuration with `<MinVerTagPrefix>` and `<MinVerDefaultPreReleaseIdentifiers>`, and included MinVer as a package reference to automate versioning based on Git tags.