### PR TITLE
Update build and publish workflows to use .NET 10.0.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -13,16 +13,15 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v5
-    
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '9.0.x'
-    
-    - name: Restore dependencies
-      run: dotnet restore DotNetMcp/DotNetMcp.csproj
-    
-    - name: Build
-      run: dotnet build DotNetMcp/DotNetMcp.csproj --no-restore --configuration Release
-    
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore DotNetMcp/DotNetMcp.csproj
+
+      - name: Build
+        run: dotnet build DotNetMcp/DotNetMcp.csproj --no-restore --configuration Release

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -3,24 +3,24 @@ name: Publish NuGet Package
 on:
   push:
     tags:
-      - 'v*'  # Only runs on version tags like v1.0.0, v0.1.0-alpha.1
+      - "v*" # Only runs on version tags like v1.0.0, v0.1.0-alpha.1
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # Required for OIDC token issuance (Trusted Publishing)
+      id-token: write # Required for OIDC token issuance (Trusted Publishing)
 
     steps:
       - uses: actions/checkout@v5
         with:
-          fetch-depth: 0  # Required for MinVer to access Git history and tags
+          fetch-depth: 0 # Required for MinVer to access Git history and tags
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: "10.0.x"
 
       - name: Restore dependencies
         run: dotnet restore DotNetMcp/DotNetMcp.csproj
@@ -96,7 +96,7 @@ jobs:
           SUCCESS=0
           SKIPPED=0
           FAILED=0
-          
+
           for package in ./artifacts/*.nupkg; do
             echo "?? Pushing $(basename "$package")..."
             
@@ -122,11 +122,11 @@ jobs:
             fi
             echo ""
           done
-          
+
           echo "?? Summary: $SUCCESS succeeded, $SKIPPED skipped, $FAILED failed"
-          
+
           if [ $FAILED -gt 0 ]; then
             exit 1
           fi
-          
+
           echo "? NuGet push completed"


### PR DESCRIPTION
This pull request updates the CI workflows to use .NET 10.0.x instead of 9.0.x for both building and publishing the NuGet package. This ensures that the project is built and published using the latest major version of .NET.

Workflow updates:

* Updated the `dotnet-version` in `.github/workflows/build.yml` from `9.0.x` to `10.0.x` to use the latest .NET version for building the project.
* Updated the `dotnet-version` in `.github/workflows/publish-nuget.yml` from `9.0.x` to `10.0.x` for publishing the NuGet package.

Minor workflow formatting:

* Changed the tag pattern in `.github/workflows/publish-nuget.yml` to use double quotes for consistency.