### PR TITLE
Add template cache management methods and improve output handling

### DIFF
--- a/DotNetMcp/DotNetCliTools.cs
+++ b/DotNetMcp/DotNetCliTools.cs
@@ -465,7 +465,9 @@ public sealed class DotNetCliTools
         {
             if (e.Data != null)
             {
-                if (output.Length < MaxOutputCharacters)
+                // Check if adding this line would exceed the limit
+                int projectedLength = output.Length + e.Data.Length + Environment.NewLine.Length;
+                if (projectedLength < MaxOutputCharacters)
                 {
                     output.AppendLine(e.Data);
                 }
@@ -481,7 +483,9 @@ public sealed class DotNetCliTools
         {
             if (e.Data != null)
             {
-                if (error.Length < MaxOutputCharacters)
+                // Check if adding this line would exceed the limit
+                int projectedLength = error.Length + e.Data.Length + Environment.NewLine.Length;
+                if (projectedLength < MaxOutputCharacters)
                 {
                     error.AppendLine(e.Data);
                 }

--- a/DotNetMcp/TemplateEngineHelper.cs
+++ b/DotNetMcp/TemplateEngineHelper.cs
@@ -16,8 +16,10 @@ namespace DotNetMcp;
 /// The cache expires after 5 minutes to allow for template installations/updates.
 /// All public methods are thread-safe and may be called concurrently.
 /// 
-/// The SemaphoreSlim instance is static and lives for the application lifetime (singleton pattern).
-/// It does not require disposal as it will be cleaned up when the process exits.
+/// The SemaphoreSlim instance is static and follows a singleton pattern for the application lifetime.
+/// While this is appropriate for typical MCP server scenarios where the process runs until termination,
+/// proper cleanup can be performed by calling <see cref="DisposeAsync"/> in testing or hosting scenarios
+/// where the application may be stopped and restarted without process termination.
 /// </remarks>
 public class TemplateEngineHelper
 {
@@ -72,6 +74,20 @@ public class TemplateEngineHelper
         {
             _cacheLock.Release();
         }
+    }
+
+    /// <summary>
+    /// Dispose of the SemaphoreSlim resource. This should be called when the helper is no longer needed,
+    /// particularly in testing or hosting scenarios where the application may be stopped/restarted.
+    /// </summary>
+    /// <remarks>
+    /// This method is provided to follow IDisposable best practices. In typical MCP server scenarios
+    /// where the process runs until termination, calling this method is not necessary.
+    /// This method is NOT thread-safe and should only be called when all other operations have completed.
+    /// </remarks>
+    public static void Dispose()
+    {
+        _cacheLock.Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request introduces template caching to improve performance for repeated template queries in the .NET MCP tools, adds cache management commands, and enhances output handling for large results. The main changes are grouped below:

**Template Caching and Management**
* Added caching to `TemplateEngineHelper` for installed .NET templates, using `SemaphoreSlim` for thread-safe access and a 5-minute cache expiry. This significantly improves performance for repeated template queries.
* Provided new methods `ClearCache()` and `ClearCacheAsync()` in `TemplateEngineHelper` to allow manual cache clearing after template installs/uninstalls.
* Updated all template query methods (`GetInstalledTemplatesAsync`, `GetTemplateDetailsAsync`, `SearchTemplatesAsync`, `ValidateTemplateExistsAsync`) to use the new caching mechanism instead of reloading templates from disk each time. [[1]](diffhunk://#diff-fd12da1fe2f8da9928ae9c805a284353612871de5075209304b1eadb960ac9a7L74-R149) [[2]](diffhunk://#diff-fd12da1fe2f8da9928ae9c805a284353612871de5075209304b1eadb960ac9a7L129-R198) [[3]](diffhunk://#diff-fd12da1fe2f8da9928ae9c805a284353612871de5075209304b1eadb960ac9a7L183-R246)

**CLI Tool Enhancements**
* Added a new server tool method `DotnetTemplateClearCache()` in `DotNetCliTools.cs` to expose template cache clearing functionality to users.

**Output Handling Improvements**
* Implemented output truncation logic in `DotNetCliTools.cs` to prevent excessively large output (>1MB) from dotnet CLI commands, improving reliability and preventing resource exhaustion. [[1]](diffhunk://#diff-896998fb9ec4aa54439620f0f07feeacaf272237047bde7866895639900c495cR443-R444) [[2]](diffhunk://#diff-896998fb9ec4aa54439620f0f07feeacaf272237047bde7866895639900c495cL451-R494)