### PR TITLE
Add DotNetMcp.Tests with unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,10 @@ jobs:
           dotnet-version: "10.0.x"
 
       - name: Restore dependencies
-        run: dotnet restore DotNetMcp/DotNetMcp.csproj
+        run: dotnet restore DotNetMcp.slnx
 
       - name: Build
-        run: dotnet build DotNetMcp/DotNetMcp.csproj --no-restore --configuration Release
+        run: dotnet build DotNetMcp.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test DotNetMcp.slnx --no-build --configuration Release --verbosity normal

--- a/DotNetMcp.Tests/DotNetMcp.Tests.csproj
+++ b/DotNetMcp.Tests/DotNetMcp.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotNetMcp\DotNetMcp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DotNetMcp.Tests/DotNetSdkConstantsTests.cs
+++ b/DotNetMcp.Tests/DotNetSdkConstantsTests.cs
@@ -1,0 +1,82 @@
+using DotNetMcp;
+using FluentAssertions;
+using Xunit;
+
+namespace DotNetMcp.Tests;
+
+public class DotNetSdkConstantsTests
+{
+    [Fact]
+    public void TargetFrameworks_ContainsModernNetVersions()
+    {
+        // Assert
+        DotNetSdkConstants.TargetFrameworks.Net90.Should().Be("net9.0");
+        DotNetSdkConstants.TargetFrameworks.Net80.Should().Be("net8.0");
+        DotNetSdkConstants.TargetFrameworks.Net70.Should().Be("net7.0");
+        DotNetSdkConstants.TargetFrameworks.Net60.Should().Be("net6.0");
+        DotNetSdkConstants.TargetFrameworks.Net50.Should().Be("net5.0");
+    }
+
+    [Fact]
+    public void TargetFrameworks_ContainsNetCoreVersions()
+    {
+        // Assert
+        DotNetSdkConstants.TargetFrameworks.NetCoreApp31.Should().Be("netcoreapp3.1");
+        DotNetSdkConstants.TargetFrameworks.NetCoreApp21.Should().Be("netcoreapp2.1");
+    }
+
+    [Fact]
+    public void TargetFrameworks_ContainsNetStandardVersions()
+    {
+        // Assert
+        DotNetSdkConstants.TargetFrameworks.NetStandard21.Should().Be("netstandard2.1");
+        DotNetSdkConstants.TargetFrameworks.NetStandard20.Should().Be("netstandard2.0");
+    }
+
+    [Fact]
+    public void Configurations_ContainsDebugAndRelease()
+    {
+        // Assert
+        DotNetSdkConstants.Configurations.Debug.Should().Be("Debug");
+        DotNetSdkConstants.Configurations.Release.Should().Be("Release");
+    }
+
+    [Fact]
+    public void RuntimeIdentifiers_ContainsCommonPlatforms()
+    {
+        // Assert
+        DotNetSdkConstants.RuntimeIdentifiers.WinX64.Should().Be("win-x64");
+        DotNetSdkConstants.RuntimeIdentifiers.LinuxX64.Should().Be("linux-x64");
+        DotNetSdkConstants.RuntimeIdentifiers.OsxArm64.Should().Be("osx-arm64");
+    }
+
+    [Fact]
+    public void Templates_ContainsCommonTemplates()
+    {
+        // Assert
+        DotNetSdkConstants.Templates.Console.Should().Be("console");
+        DotNetSdkConstants.Templates.WebApi.Should().Be("webapi");
+        DotNetSdkConstants.Templates.Blazor.Should().Be("blazor");
+        DotNetSdkConstants.Templates.XUnit.Should().Be("xunit");
+    }
+
+    [Fact]
+    public void CommonPackages_ContainsWellKnownPackages()
+    {
+        // Assert
+        DotNetSdkConstants.CommonPackages.NewtonsoftJson.Should().Be("Newtonsoft.Json");
+        DotNetSdkConstants.CommonPackages.EFCore.Should().Be("Microsoft.EntityFrameworkCore");
+        DotNetSdkConstants.CommonPackages.XUnitCore.Should().Be("xunit");
+    }
+
+    [Fact]
+    public void VerbosityLevels_ContainsAllLevels()
+    {
+        // Assert
+        DotNetSdkConstants.VerbosityLevels.Quiet.Should().Be("quiet");
+        DotNetSdkConstants.VerbosityLevels.Minimal.Should().Be("minimal");
+        DotNetSdkConstants.VerbosityLevels.Normal.Should().Be("normal");
+        DotNetSdkConstants.VerbosityLevels.Detailed.Should().Be("detailed");
+        DotNetSdkConstants.VerbosityLevels.Diagnostic.Should().Be("diagnostic");
+    }
+}

--- a/DotNetMcp.Tests/FrameworkHelperTests.cs
+++ b/DotNetMcp.Tests/FrameworkHelperTests.cs
@@ -1,0 +1,170 @@
+using DotNetMcp;
+using FluentAssertions;
+using Xunit;
+
+namespace DotNetMcp.Tests;
+
+public class FrameworkHelperTests
+{
+    [Theory]
+    [InlineData("net9.0", true)]
+    [InlineData("net8.0", true)]
+    [InlineData("net7.0", true)]
+    [InlineData("netcoreapp3.1", true)]
+    [InlineData("netstandard2.0", true)]
+    [InlineData("netstandard2.1", true)]
+    [InlineData("invalid", false)]
+    [InlineData("", false)]
+    public void IsValidFramework_ValidatesCorrectly(string tfm, bool expected)
+    {
+        // Act
+        var result = FrameworkHelper.IsValidFramework(tfm);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("net8.0", true)]
+    [InlineData("net6.0", true)]
+    [InlineData("netcoreapp3.1", true)]
+    [InlineData("netcoreapp2.1", true)]
+    [InlineData("net9.0", false)]
+    [InlineData("net7.0", false)]
+    [InlineData("net5.0", false)]
+    public void IsLtsFramework_IdentifiesLtsCorrectly(string tfm, bool expected)
+    {
+        // Act
+        var result = FrameworkHelper.IsLtsFramework(tfm);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("net9.0", ".NET 9.0")]
+    [InlineData("net8.0", ".NET 8.0 (LTS)")]
+    [InlineData("net6.0", ".NET 6.0 (LTS)")]
+    [InlineData("netcoreapp3.1", ".NET Core 3.1 (LTS)")]
+    [InlineData("netstandard2.0", ".NET Standard 2.0")]
+    public void GetFrameworkDescription_ReturnsCorrectDescription(string tfm, string expected)
+    {
+        // Act
+        var result = FrameworkHelper.GetFrameworkDescription(tfm);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetLatestRecommendedFramework_ReturnsNet90()
+    {
+        // Act
+        var result = FrameworkHelper.GetLatestRecommendedFramework();
+
+        // Assert
+        result.Should().Be("net9.0");
+    }
+
+    [Fact]
+    public void GetLatestLtsFramework_ReturnsNet80()
+    {
+        // Act
+        var result = FrameworkHelper.GetLatestLtsFramework();
+
+        // Assert
+        result.Should().Be("net8.0");
+    }
+
+    [Theory]
+    [InlineData("net9.0", true)]
+    [InlineData("net8.0", true)]
+    [InlineData("net5.0", true)]
+    [InlineData("netcoreapp3.1", false)]
+    [InlineData("netstandard2.0", false)]
+    [InlineData("net48", false)]
+    public void IsModernNet_ClassifiesCorrectly(string tfm, bool expected)
+    {
+        // Act
+        var result = FrameworkHelper.IsModernNet(tfm);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("netcoreapp3.1", true)]
+    [InlineData("netcoreapp2.1", true)]
+    [InlineData("net9.0", false)]
+    [InlineData("netstandard2.0", false)]
+    public void IsNetCore_ClassifiesCorrectly(string tfm, bool expected)
+    {
+        // Act
+        var result = FrameworkHelper.IsNetCore(tfm);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("net48", true)]
+    [InlineData("net472", true)]
+    [InlineData("net9.0", false)]
+    [InlineData("netcoreapp3.1", false)]
+    public void IsNetFramework_ClassifiesCorrectly(string tfm, bool expected)
+    {
+        // Act
+        var result = FrameworkHelper.IsNetFramework(tfm);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("netstandard2.1", true)]
+    [InlineData("netstandard2.0", true)]
+    [InlineData("net9.0", false)]
+    [InlineData("netcoreapp3.1", false)]
+    public void IsNetStandard_ClassifiesCorrectly(string tfm, bool expected)
+    {
+        // Act
+        var result = FrameworkHelper.IsNetStandard(tfm);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetSupportedModernFrameworks_ReturnsExpectedCount()
+    {
+        // Act
+        var result = FrameworkHelper.GetSupportedModernFrameworks();
+
+        // Assert
+        result.Count.Should().BeGreaterThanOrEqualTo(5);
+        result.Should().Contain("net9.0");
+        result.Should().Contain("net8.0");
+    }
+
+    [Fact]
+    public void GetSupportedNetCoreFrameworks_ReturnsExpectedFrameworks()
+    {
+        // Act
+        var result = FrameworkHelper.GetSupportedNetCoreFrameworks();
+
+        // Assert
+        result.Should().Contain("netcoreapp3.1");
+        result.Should().Contain("netcoreapp2.1");
+    }
+
+    [Fact]
+    public void GetSupportedNetStandardFrameworks_ReturnsExpectedFrameworks()
+    {
+        // Act
+        var result = FrameworkHelper.GetSupportedNetStandardFrameworks();
+
+        // Assert
+        result.Should().Contain("netstandard2.1");
+        result.Should().Contain("netstandard2.0");
+    }
+}

--- a/DotNetMcp.slnx
+++ b/DotNetMcp.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="DotNetMcp/DotNetMcp.csproj" />
+  <Project Path="DotNetMcp.Tests/DotNetMcp.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
This pull request introduces a comprehensive test suite for the project and updates the build workflow to include automated test execution. The main changes add a new test project with unit tests for key utility classes, and ensure that tests are run as part of the CI pipeline.

**Testing infrastructure:**

* Added a new test project `DotNetMcp.Tests` with dependencies on `xunit`, `FluentAssertions`, and other common .NET testing packages. The test project targets .NET 9.0 and references the main project. [[1]](diffhunk://#diff-52bca8be801b6825e1398832da590389820926147e1b843081402d4286f50090R1-R27) [[2]](diffhunk://#diff-a1a5248dd840e875c2d9185c166bf3829be478eecbe9cd71b11d6b0496cbf0e6R3)
* Implemented unit tests for `FrameworkHelper`, covering framework validation, classification, and utility methods.
* Added unit tests for `DotNetSdkConstants`, verifying the presence and correctness of framework names, configurations, runtime identifiers, templates, packages, and verbosity levels.

**Continuous Integration (CI) improvements:**

* Updated the GitHub Actions workflow to restore, build, and test the solution using the `.slnx` file. The workflow now runs tests automatically after building.