### PR TITLE
Fix server.json: Remove packageArguments for MCP registry compatibility

### DIFF
--- a/DotNetMcp/.mcp/server.json
+++ b/DotNetMcp/.mcp/server.json
@@ -15,7 +15,6 @@
       "transport": {
         "type": "stdio"
       },
-      "packageArguments": ["--yes"],
       "environmentVariables": [
         {
           "name": "DOTNET_SKIP_FIRST_TIME_EXPERIENCE",


### PR DESCRIPTION
## Problem

The MCP registry publisher was failing with:
```
Error: invalid server.json: json: cannot unmarshal string into Go struct field Package.packages.packageArguments of type model.Argument
```

This was blocking the v0.1.0-rc1 release from being published to the MCP registry.

## Root Cause

The `packageArguments` field in `.mcp/server.json` was defined as a string array:
```json
"packageArguments": ["--yes"]
```

However, the MCP registry publisher expects this field to either:
- Be absent (recommended for simple cases)
- Be an array of `Argument` objects (complex structure)

## Solution

Removed the `packageArguments` field entirely. The `--yes` flag is not needed for registry publishing and can be specified by users when they configure their MCP client if desired.

## Testing

- ✅ Build succeeds
- ✅ server.json is valid JSON
- ✅ Ready for republishing to MCP registry

## Next Steps

After merging:
1. Delete the existing `v0.1.0-rc1` tag from remote
2. Create a new `v0.1.0-rc1` tag from the updated main branch
3. Push the tag to trigger publishing workflow