### PR TITLE
Fix server.json: Shorten description to meet MCP registry 100 char limit

### DIFF
--- a/DotNetMcp/.mcp/server.json
+++ b/DotNetMcp/.mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.jongalloway/dotnet-mcp",
   "title": ".NET MCP Server",
-  "description": "A community-maintained MCP server that provides AI assistants with direct access to the .NET SDK for project creation, package management, building, testing, and more.",
+  "description": "AI assistant access to .NET SDK for projects, packages, building, testing, and development tools.",
   "status": "active",
   "version": "0.0.0-placeholder",
   "packages": [


### PR DESCRIPTION
## Problem

MCP registry publishing failed with:
```
Error: publish failed: server returned status 422: 
{"title":"Unprocessable Entity","status":422,"detail":"validation failed",
"errors":[{"message":"expected length <= 100","location":"body.description"}]}
```

The description was 172 characters, exceeding the 100-character limit.

## Solution

Shortened description from:
```
A community-maintained MCP server that provides AI assistants with direct access to the .NET SDK for project creation, package management, building, testing, and more.
```
(172 characters)

To:
```
AI assistant access to .NET SDK for projects, packages, building, testing, and development tools.
```
(97 characters)

## Testing

- ✅ Description is now 97 characters (under 100 limit)
- ✅ Maintains key information about the server's purpose
- ✅ Ready for MCP registry publishing