### PR TITLE
Refactor tests to use cancellation tokens for improved task management

### DIFF
--- a/DotNetMcp.Tests/CacheMetricsTests.cs
+++ b/DotNetMcp.Tests/CacheMetricsTests.cs
@@ -121,8 +121,8 @@ public class CacheMetricsTests
         // Act - Concurrently record hits and misses
         for (int i = 0; i < 100; i++)
         {
-            tasks.Add(Task.Run(() => metrics.RecordHit()));
-            tasks.Add(Task.Run(() => metrics.RecordMiss()));
+            tasks.Add(Task.Run(() => metrics.RecordHit(), TestContext.Current.CancellationToken));
+            tasks.Add(Task.Run(() => metrics.RecordMiss(), TestContext.Current.CancellationToken));
         }
 
         await Task.WhenAll(tasks);

--- a/DotNetMcp.Tests/CachedResourceManagerTests.cs
+++ b/DotNetMcp.Tests/CachedResourceManagerTests.cs
@@ -16,7 +16,7 @@ public class CachedResourceManagerTests
         var entry = await manager.GetOrLoadAsync(async () =>
         {
             loadCount++;
-            await Task.Delay(10);
+            await Task.Delay(10, TestContext.Current.CancellationToken);
             return "test data";
         });
 
@@ -38,14 +38,14 @@ public class CachedResourceManagerTests
         var entry1 = await manager.GetOrLoadAsync(async () =>
         {
             loadCount++;
-            await Task.Delay(10);
+            await Task.Delay(10, TestContext.Current.CancellationToken);
             return "test data";
         });
 
         var entry2 = await manager.GetOrLoadAsync(async () =>
         {
             loadCount++;
-            await Task.Delay(10);
+            await Task.Delay(10, TestContext.Current.CancellationToken);
             return "test data";
         });
 
@@ -100,7 +100,7 @@ public class CachedResourceManagerTests
         });
 
         // Wait for cache to expire
-        await Task.Delay(1100);
+        await Task.Delay(1100, TestContext.Current.CancellationToken);
 
         // Load again
         var entry2 = await manager.GetOrLoadAsync(async () =>

--- a/DotNetMcp.Tests/CancellationTests.cs
+++ b/DotNetMcp.Tests/CancellationTests.cs
@@ -18,14 +18,14 @@ public class CancellationTests
     public async Task ExecuteCommandAsync_WhenCancelled_ShouldTerminateProcess()
     {
         // Arrange
-        using var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var arguments = "run --project NonExistentProject.csproj"; // A command that would take time
 
         // Act
         var task = DotNetCommandExecutor.ExecuteCommandAsync(arguments, _logger, machineReadable: false, unsafeOutput: false, cts.Token);
-        
+
         // Cancel after a short delay
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
         cts.Cancel();
 
         var result = await task;
@@ -39,14 +39,14 @@ public class CancellationTests
     public async Task ExecuteCommandAsync_WhenCancelledWithMachineReadable_ShouldReturnStructuredError()
     {
         // Arrange
-        using var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var arguments = "run --project NonExistentProject.csproj";
 
         // Act
         var task = DotNetCommandExecutor.ExecuteCommandAsync(arguments, _logger, machineReadable: true, unsafeOutput: false, cts.Token);
-        
+
         // Cancel after a short delay
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
         cts.Cancel();
 
         var result = await task;
@@ -61,12 +61,12 @@ public class CancellationTests
     public async Task ExecuteCommandForResourceAsync_WhenCancelled_ShouldThrowOperationCanceledException()
     {
         // Arrange
-        using var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var arguments = "--version"; // Quick command
 
         // Act
         var task = DotNetCommandExecutor.ExecuteCommandForResourceAsync(arguments, _logger, cts.Token);
-        
+
         // Cancel immediately
         cts.Cancel();
 
@@ -78,7 +78,7 @@ public class CancellationTests
     public async Task ExecuteCommandAsync_WithValidCancellationToken_ShouldAcceptIt()
     {
         // Arrange
-        using var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var arguments = "--version"; // Quick command that should succeed
 
         // Act - should complete without cancellation
@@ -97,7 +97,9 @@ public class CancellationTests
         var arguments = "--version";
 
         // Act - using default cancellation token
+#pragma warning disable xUnit1051
         var result = await DotNetCommandExecutor.ExecuteCommandAsync(arguments, _logger, machineReadable: false);
+#pragma warning restore xUnit1051
 
         // Assert
         Assert.NotNull(result);

--- a/DotNetMcp.Tests/CommandExecutorRedactionTests.cs
+++ b/DotNetMcp.Tests/CommandExecutorRedactionTests.cs
@@ -26,7 +26,8 @@ public class CommandExecutorRedactionTests
             arguments,
             _logger,
             machineReadable: false,
-            unsafeOutput: false);
+            unsafeOutput: false,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert - should complete successfully
         Assert.NotNull(result);
@@ -45,7 +46,8 @@ public class CommandExecutorRedactionTests
             arguments,
             _logger,
             machineReadable: false,
-            unsafeOutput: true);
+            unsafeOutput: true,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert - should complete successfully
         Assert.NotNull(result);
@@ -65,7 +67,8 @@ public class CommandExecutorRedactionTests
             arguments,
             _logger,
             machineReadable: false,
-            unsafeOutput: false);
+            unsafeOutput: false,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert - should complete successfully
         Assert.NotNull(result);
@@ -84,7 +87,8 @@ public class CommandExecutorRedactionTests
             arguments,
             _logger,
             machineReadable: true,
-            unsafeOutput: false);
+            unsafeOutput: false,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert - should return JSON format
         Assert.Contains("\"success\"", result);
@@ -100,7 +104,8 @@ public class CommandExecutorRedactionTests
         // Act
         var result = await DotNetCommandExecutor.ExecuteCommandForResourceAsync(
             arguments,
-            _logger);
+            _logger,
+            TestContext.Current.CancellationToken);
 
         // Assert - should complete successfully with redaction applied
         Assert.NotNull(result);


### PR DESCRIPTION
This pull request updates several unit tests to improve cancellation handling and ensure tests respect the test framework's cancellation semantics. The main focus is on passing `TestContext.Current.CancellationToken` to asynchronous operations and task scheduling, which helps with test reliability and proper cancellation propagation.

**Test cancellation and context propagation improvements:**

* All relevant `Task.Delay` and `Task.Run` calls in test methods now use `TestContext.Current.CancellationToken` to ensure operations are cancellable according to the test framework context. [[1]](diffhunk://#diff-c2975d1e7ef6b38a14c79af4b0bc9215ae944ce8ef9509a2b62bfdf4860d4517L19-R19) [[2]](diffhunk://#diff-c2975d1e7ef6b38a14c79af4b0bc9215ae944ce8ef9509a2b62bfdf4860d4517L41-R48) [[3]](diffhunk://#diff-c2975d1e7ef6b38a14c79af4b0bc9215ae944ce8ef9509a2b62bfdf4860d4517L103-R103) [[4]](diffhunk://#diff-1eff6e388e6089729186a02611b609ebfe9e49c65b801ac58b8cf7ca023592d5L124-R125) [[5]](diffhunk://#diff-2675162fd41444625e9ee713dbef24e388619a47546e55656236acc9aad69869L21-R28) [[6]](diffhunk://#diff-2675162fd41444625e9ee713dbef24e388619a47546e55656236acc9aad69869L42-R49)
* Test methods that create `CancellationTokenSource` instances now use `CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken)` to link with the test context's cancellation token, improving test cancellation behavior. [[1]](diffhunk://#diff-2675162fd41444625e9ee713dbef24e388619a47546e55656236acc9aad69869L21-R28) [[2]](diffhunk://#diff-2675162fd41444625e9ee713dbef24e388619a47546e55656236acc9aad69869L42-R49) [[3]](diffhunk://#diff-2675162fd41444625e9ee713dbef24e388619a47546e55656236acc9aad69869L64-R64) [[4]](diffhunk://#diff-2675162fd41444625e9ee713dbef24e388619a47546e55656236acc9aad69869L81-R81)

**Test method signature and invocation updates:**

* All invocations of `DotNetCommandExecutor.ExecuteCommandAsync` and `ExecuteCommandForResourceAsync` in redaction-related tests now explicitly pass `TestContext.Current.CancellationToken` as the cancellation token argument, ensuring consistent cancellation support. [[1]](diffhunk://#diff-acdf776aecf27f9d4163d68003b2206bda2237a0a98f80689d01f70c13afdf0eL29-R30) [[2]](diffhunk://#diff-acdf776aecf27f9d4163d68003b2206bda2237a0a98f80689d01f70c13afdf0eL48-R50) [[3]](diffhunk://#diff-acdf776aecf27f9d4163d68003b2206bda2237a0a98f80689d01f70c13afdf0eL68-R71) [[4]](diffhunk://#diff-acdf776aecf27f9d4163d68003b2206bda2237a0a98f80689d01f70c13afdf0eL87-R91) [[5]](diffhunk://#diff-acdf776aecf27f9d4163d68003b2206bda2237a0a98f80689d01f70c13afdf0eL103-R108)
* A pragma directive is added to suppress xUnit warning 1051 in a test that intentionally omits a cancellation token, clarifying intent and avoiding unnecessary test warnings.