### PR TITLE
Fix Codecov upload condition in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,8 @@ jobs:
           cp "${coverage_file}" coverage.cobertura.xml
 
       - name: Upload coverage to Codecov
-        # Secrets aren't available to workflows triggered from forks.
-        if: secrets.CODECOV_TOKEN
+        # Only upload from pushes (PR workflows from forks don't have secrets).
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: codecov/codecov-action@v5
         with:
           files: coverage.cobertura.xml


### PR DESCRIPTION
This pull request updates the workflow for uploading code coverage reports to Codecov. The upload step is now restricted to only run on pushes to the `main` branch, rather than being gated by the presence of the Codecov token secret.

**Workflow improvements:**

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L66-R67): Changed the condition for uploading coverage to Codecov so that it only runs on push events to the `main` branch, ensuring coverage uploads do not occur from forked pull requests.…in push events