### PR TITLE
Refactor DotnetToolManifestCreate

### DIFF
--- a/DotNetMcp.Tests/Tools/EdgeCaseAndIntegrationTests.cs
+++ b/DotNetMcp.Tests/Tools/EdgeCaseAndIntegrationTests.cs
@@ -352,21 +352,20 @@ public class EdgeCaseAndIntegrationTests
     {
         // Act
         // Use an isolated output directory to avoid relying on current working directory state.
-        var tempDirectory = Path.Combine(Path.GetTempPath(), "dotnet-mcp-tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempDirectory);
+        var tempDirectory = Directory.CreateTempSubdirectory("dotnet-mcp-tests");
 
         string result;
         try
         {
             result = await _tools.DotnetToolManifestCreate(
-                output: tempDirectory,
+                output: tempDirectory.FullName,
                 force: true,
                 machineReadable: true);
         }
         finally
         {
-            if (Directory.Exists(tempDirectory))
-                Directory.Delete(tempDirectory, recursive: true);
+            if (tempDirectory.Exists)
+                tempDirectory.Delete(recursive: true);
         }
 
         // Assert


### PR DESCRIPTION
This pull request improves the reliability of the `DotnetToolManifestCreate_WithMachineReadable_BuildsCorrectCommand` test by ensuring it uses an isolated temporary directory for its output, rather than relying on the current working directory. This helps prevent test interference and side effects.

**Testing improvements:**

* The test now creates a unique temporary directory for the tool manifest output and ensures the directory is cleaned up after the test completes, even if an exception occurs.