### PR TITLE
Add working directory support and validation for DotNetCliTools

### DIFF
--- a/DotNetMcp.Tests/Execution/WorkingDirectoryTests.cs
+++ b/DotNetMcp.Tests/Execution/WorkingDirectoryTests.cs
@@ -1,0 +1,94 @@
+using DotNetMcp;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DotNetMcp.Tests;
+
+public class WorkingDirectoryTests
+{
+    private readonly ILogger _logger;
+
+    public WorkingDirectoryTests()
+    {
+        _logger = NullLogger.Instance;
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_WithExistingWorkingDirectory_Succeeds()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), "dotnet-mcp-wd-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // Act
+            var result = await DotNetCommandExecutor.ExecuteCommandAsync(
+                "--version",
+                _logger,
+                machineReadable: false,
+                unsafeOutput: false,
+                cancellationToken: TestContext.Current.CancellationToken,
+                workingDirectory: tempDir);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotEmpty(result);
+            Assert.Contains("Exit Code: 0", result);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_WithMissingWorkingDirectory_ReturnsValidationErrorPlainText()
+    {
+        // Arrange
+        var missingDir = Path.Combine(Path.GetTempPath(), "dotnet-mcp-missing-" + Guid.NewGuid().ToString("N"));
+
+        // Act
+        var result = await DotNetCommandExecutor.ExecuteCommandAsync(
+            "--version",
+            _logger,
+            machineReadable: false,
+            unsafeOutput: false,
+            cancellationToken: TestContext.Current.CancellationToken,
+            workingDirectory: missingDir);
+
+        // Assert
+        Assert.Contains("Error:", result);
+        Assert.Contains("workingDirectory", result);
+        Assert.Contains("Directory not found", result);
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_WithMissingWorkingDirectory_ReturnsValidationErrorJson()
+    {
+        // Arrange
+        var missingDir = Path.Combine(Path.GetTempPath(), "dotnet-mcp-missing-" + Guid.NewGuid().ToString("N"));
+
+        // Act
+        var result = await DotNetCommandExecutor.ExecuteCommandAsync(
+            "--version",
+            _logger,
+            machineReadable: true,
+            unsafeOutput: false,
+            cancellationToken: TestContext.Current.CancellationToken,
+            workingDirectory: missingDir);
+
+        // Assert
+        Assert.Contains("\"success\": false", result);
+        Assert.Contains("INVALID_PARAMS", result);
+        Assert.Contains("workingDirectory", result);
+    }
+}

--- a/DotNetMcp.Tests/Tools/ConsolidatedSdkToolTests.cs
+++ b/DotNetMcp.Tests/Tools/ConsolidatedSdkToolTests.cs
@@ -24,6 +24,22 @@ public class ConsolidatedSdkToolTests
         _tools = new DotNetCliTools(_logger, _concurrencyManager);
     }
 
+    [Fact]
+    public async Task DotnetSdk_WithMissingWorkingDirectory_MachineReadable_ReturnsValidationError()
+    {
+        var missingDir = Path.Combine(Path.GetTempPath(), "dotnet-mcp-missing-" + Guid.NewGuid().ToString("N"));
+
+        var result = await _tools.DotnetSdk(
+            action: DotnetSdkAction.Version,
+            workingDirectory: missingDir,
+            machineReadable: true);
+
+        Assert.NotNull(result);
+        Assert.Contains("\"success\": false", result);
+        Assert.Contains("INVALID_PARAMS", result);
+        Assert.Contains("workingDirectory", result, StringComparison.OrdinalIgnoreCase);
+    }
+
     #region Version Action Tests
 
     [Fact]


### PR DESCRIPTION
- Introduced a new optional parameter for working directory in various command execution methods across DotNetCliTools.
- Implemented validation for the working directory to ensure it exists and is valid, returning structured error messages in machine-readable format.
- Updated existing tests to cover scenarios where the working directory is missing or invalid.
- Enhanced the DotNetCommandExecutor to utilize the working directory parameter during command execution.

Fixes #216 