### PR TITLE
Refine consolidated tool surface and migrate tests

### DIFF
--- a/DotNetMcp.Tests/Contract/MachineReadableContractComplianceTests.cs
+++ b/DotNetMcp.Tests/Contract/MachineReadableContractComplianceTests.cs
@@ -28,28 +28,28 @@ public class MachineReadableContractComplianceTests
     [Fact]
     public async Task DotnetSdkVersion_MachineReadable_ReturnsValidSuccessEnvelope()
     {
-        var result = await _tools.DotnetSdkVersion(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Version, machineReadable: true);
         AssertSuccessEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetSdkInfo_MachineReadable_ReturnsValidSuccessEnvelope()
     {
-        var result = await _tools.DotnetSdkInfo(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Info, machineReadable: true);
         AssertSuccessEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetSdkList_MachineReadable_ReturnsValidSuccessEnvelope()
     {
-        var result = await _tools.DotnetSdkList(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.ListSdks, machineReadable: true);
         AssertSuccessEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetRuntimeList_MachineReadable_ReturnsValidSuccessEnvelope()
     {
-        var result = await _tools.DotnetRuntimeList(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.ListRuntimes, machineReadable: true);
         AssertSuccessEnvelope(result);
     }
 
@@ -60,56 +60,81 @@ public class MachineReadableContractComplianceTests
     [Fact]
     public async Task DotnetToolInstall_EmptyPackageName_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetToolInstall(packageName: "", machineReadable: true);
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "",
+            machineReadable: true);
         AssertValidationErrorEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetToolUpdate_EmptyPackageName_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetToolUpdate(packageName: "", machineReadable: true);
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Update,
+            packageId: "",
+            machineReadable: true);
         AssertValidationErrorEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetToolUninstall_EmptyPackageName_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetToolUninstall(packageName: "", machineReadable: true);
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Uninstall,
+            packageId: "",
+            machineReadable: true);
         AssertValidationErrorEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetSecretsSet_EmptyKey_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetSecretsSet(key: "", value: "test", machineReadable: true);
+        var result = await _tools.DotnetDevCerts(
+            action: DotNetMcp.Actions.DotnetDevCertsAction.SecretsSet,
+            key: "",
+            value: "test",
+            machineReadable: true);
         AssertValidationErrorEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetSecretsSet_EmptyValue_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetSecretsSet(key: "test", value: "", machineReadable: true);
+        var result = await _tools.DotnetDevCerts(
+            action: DotNetMcp.Actions.DotnetDevCertsAction.SecretsSet,
+            key: "test",
+            value: "",
+            machineReadable: true);
         AssertValidationErrorEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetCertificateExport_EmptyPath_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetCertificateExport(path: "", machineReadable: true);
+        var result = await _tools.DotnetDevCerts(
+            action: DotNetMcp.Actions.DotnetDevCertsAction.CertificateExport,
+            path: "",
+            machineReadable: true);
         AssertValidationErrorEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetCertificateExport_InvalidFormat_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetCertificateExport(path: "/tmp/cert.pfx", format: "invalid", machineReadable: true);
+        var result = await _tools.DotnetDevCerts(
+            action: DotNetMcp.Actions.DotnetDevCertsAction.CertificateExport,
+            path: "/tmp/cert.pfx",
+            format: "invalid",
+            machineReadable: true);
         AssertValidationErrorEnvelope(result);
     }
 
     [Fact]
     public async Task DotnetSolutionAdd_EmptyProjects_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetSolutionAdd(
+        var result = await _tools.DotnetSolution(
+            action: DotNetMcp.Actions.DotnetSolutionAction.Add,
             solution: "Test.sln",
             projects: Array.Empty<string>(),
             machineReadable: true);
@@ -119,10 +144,9 @@ public class MachineReadableContractComplianceTests
     [Fact]
     public async Task DotnetNugetLocals_NeitherListNorClear_ReturnsValidValidationError()
     {
-        var result = await _tools.DotnetNugetLocals(
-            cacheLocation: "all",
-            list: false,
-            clear: false,
+        var result = await _tools.DotnetPackage(
+            action: DotNetMcp.Actions.DotnetPackageAction.ClearCache,
+            cacheType: "invalid",
             machineReadable: true);
         AssertValidationErrorEnvelope(result);
     }
@@ -134,7 +158,8 @@ public class MachineReadableContractComplianceTests
     [Fact]
     public async Task DotnetProjectBuild_NonExistentProject_ReturnsValidErrorEnvelope()
     {
-        var result = await _tools.DotnetProjectBuild(
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Build,
             project: "/tmp/NonExistent_Project_12345.csproj",
             machineReadable: true);
         AssertErrorEnvelope(result);
@@ -143,7 +168,8 @@ public class MachineReadableContractComplianceTests
     [Fact]
     public async Task DotnetProjectRun_NonExistentProject_ReturnsValidErrorEnvelope()
     {
-        var result = await _tools.DotnetProjectRun(
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Run,
             project: "/tmp/NonExistent_Project_12345.csproj",
             machineReadable: true);
         AssertErrorEnvelope(result);

--- a/DotNetMcp.Tests/Errors/ValidationErrorTests.cs
+++ b/DotNetMcp.Tests/Errors/ValidationErrorTests.cs
@@ -29,25 +29,27 @@ public class ValidationErrorTests
     public async Task DotnetToolInstall_WithEmptyPackageName_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetToolInstall(
-            packageName: "",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "",
             machineReadable: true);
 
         // Assert
-        AssertValidationError(result, "packageName", "required");
+        AssertValidationError(result, "packageId", "required");
     }
 
     [Fact]
     public async Task DotnetToolInstall_WithEmptyPackageName_MachineReadableFalse_ReturnsPlainText()
     {
         // Act
-        var result = await _tools.DotnetToolInstall(
-            packageName: "",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "",
             machineReadable: false);
 
         // Assert
         Assert.StartsWith("Error:", result);
-        Assert.Contains("packageName", result);
+        Assert.Contains("packageId", result);
         Assert.False(TryParseJson(result, out _));
     }
 
@@ -55,31 +57,34 @@ public class ValidationErrorTests
     public async Task DotnetToolUpdate_WithEmptyPackageName_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetToolUpdate(
-            packageName: "",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Update,
+            packageId: "",
             machineReadable: true);
 
         // Assert
-        AssertValidationError(result, "packageName", "required");
+        AssertValidationError(result, "packageId", "required");
     }
 
     [Fact]
     public async Task DotnetToolUninstall_WithEmptyPackageName_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetToolUninstall(
-            packageName: "",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Uninstall,
+            packageId: "",
             machineReadable: true);
 
         // Assert
-        AssertValidationError(result, "packageName", "required");
+        AssertValidationError(result, "packageId", "required");
     }
 
     [Fact]
     public async Task DotnetToolSearch_WithEmptySearchTerm_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetToolSearch(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Search,
             searchTerm: "",
             machineReadable: true);
 
@@ -91,7 +96,8 @@ public class ValidationErrorTests
     public async Task DotnetToolRun_WithEmptyToolName_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetToolRun(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Run,
             toolName: "",
             machineReadable: true);
 
@@ -103,7 +109,8 @@ public class ValidationErrorTests
     public async Task DotnetToolRun_WithInvalidArgs_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetToolRun(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Run,
             toolName: "test-tool",
             args: "invalid<>chars",
             machineReadable: true);
@@ -283,7 +290,8 @@ public class ValidationErrorTests
     public async Task DotnetSolutionCreate_WithInvalidFormat_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetSolutionCreate(
+        var result = await _tools.DotnetSolution(
+            action: DotNetMcp.Actions.DotnetSolutionAction.Create,
             name: "TestSolution",
             format: "invalid",
             machineReadable: true);
@@ -296,7 +304,8 @@ public class ValidationErrorTests
     public async Task DotnetSolutionAdd_WithEmptyProjects_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetSolutionAdd(
+        var result = await _tools.DotnetSolution(
+            action: DotNetMcp.Actions.DotnetSolutionAction.Add,
             solution: "TestSolution.sln",
             projects: Array.Empty<string>(),
             machineReadable: true);
@@ -309,7 +318,8 @@ public class ValidationErrorTests
     public async Task DotnetSolutionRemove_WithEmptyProjects_MachineReadableTrue_ReturnsStructuredError()
     {
         // Act
-        var result = await _tools.DotnetSolutionRemove(
+        var result = await _tools.DotnetSolution(
+            action: DotNetMcp.Actions.DotnetSolutionAction.Remove,
             solution: "TestSolution.sln",
             projects: Array.Empty<string>(),
             machineReadable: true);

--- a/DotNetMcp.Tests/Performance/PerformanceSmokeTests.cs
+++ b/DotNetMcp.Tests/Performance/PerformanceSmokeTests.cs
@@ -102,7 +102,7 @@ public class PerformanceSmokeTests
         // Warmup
         for (int i = 0; i < WarmupIterations; i++)
         {
-            await _tools.DotnetSdkVersion();
+            await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Version);
         }
         
         // Measurement iterations
@@ -112,7 +112,7 @@ public class PerformanceSmokeTests
         for (int i = 0; i < MeasurementIterations; i++)
         {
             sw.Restart();
-            var result = await _tools.DotnetSdkVersion();
+            var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Version);
             sw.Stop();
             
             // Verify the call succeeded

--- a/DotNetMcp.Tests/Tools/DotNetCliToolsTests.cs
+++ b/DotNetMcp.Tests/Tools/DotNetCliToolsTests.cs
@@ -384,8 +384,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolInstall_WithPackageName_ExecutesCommand()
     {
         // Validates that tool install with package name works
-        var result = await _tools.DotnetToolInstall(
-            packageName: "dotnet-ef");
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "dotnet-ef");
 
         Assert.NotNull(result);
     }
@@ -394,8 +395,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolInstall_WithGlobalFlag_ExecutesCommand()
     {
         // Validates that global tool install works
-        var result = await _tools.DotnetToolInstall(
-            packageName: "dotnet-ef",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "dotnet-ef",
             global: true);
 
         Assert.NotNull(result);
@@ -405,8 +407,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolInstall_WithVersion_ExecutesCommand()
     {
         // Validates that tool install with specific version works
-        var result = await _tools.DotnetToolInstall(
-            packageName: "dotnet-ef",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "dotnet-ef",
             version: "8.0.0");
 
         Assert.NotNull(result);
@@ -416,8 +419,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolInstall_WithFramework_ExecutesCommand()
     {
         // Validates that tool install with framework works
-        var result = await _tools.DotnetToolInstall(
-            packageName: "dotnet-ef",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "dotnet-ef",
             framework: "net8.0");
 
         Assert.NotNull(result);
@@ -427,8 +431,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolInstall_WithAllParameters_ExecutesCommand()
     {
         // Validates that all parameters work together
-        var result = await _tools.DotnetToolInstall(
-            packageName: "dotnet-ef",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "dotnet-ef",
             global: true,
             version: "8.0.0",
             framework: "net8.0");
@@ -440,18 +445,22 @@ public class DotNetCliToolsTests
     public async Task DotnetToolInstall_WithEmptyPackageName_ReturnsError()
     {
         // Validates that empty package name returns error
-        var result = await _tools.DotnetToolInstall(
-            packageName: "");
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "");
 
         Assert.Contains("Error", result);
-        Assert.Contains("packageName parameter is required", result);
+        Assert.Contains("packageId", result);
+        Assert.Contains("required", result, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public async Task DotnetToolList_WithoutGlobalFlag_ExecutesCommand()
     {
         // Validates that local tool list works
-        var result = await _tools.DotnetToolList(machineReadable: true);
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.List,
+            machineReadable: true);
 
         Assert.NotNull(result);
         MachineReadableCommandAssertions.AssertExecutedDotnetCommand(result, "dotnet tool list");
@@ -461,7 +470,8 @@ public class DotNetCliToolsTests
     public async Task DotnetToolList_WithGlobalFlag_ExecutesCommand()
     {
         // Validates that global tool list works
-        var result = await _tools.DotnetToolList(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.List,
             global: true,
             machineReadable: true);
 
@@ -473,8 +483,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolUpdate_WithPackageName_ExecutesCommand()
     {
         // Validates that tool update with package name works
-        var result = await _tools.DotnetToolUpdate(
-            packageName: "dotnet-ef");
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Update,
+            packageId: "dotnet-ef");
 
         Assert.NotNull(result);
     }
@@ -483,8 +494,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolUpdate_WithGlobalFlag_ExecutesCommand()
     {
         // Validates that global tool update works
-        var result = await _tools.DotnetToolUpdate(
-            packageName: "dotnet-ef",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Update,
+            packageId: "dotnet-ef",
             global: true);
 
         Assert.NotNull(result);
@@ -494,8 +506,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolUpdate_WithVersion_ExecutesCommand()
     {
         // Validates that tool update to specific version works
-        var result = await _tools.DotnetToolUpdate(
-            packageName: "dotnet-ef",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Update,
+            packageId: "dotnet-ef",
             version: "8.0.1");
 
         Assert.NotNull(result);
@@ -505,19 +518,22 @@ public class DotNetCliToolsTests
     public async Task DotnetToolUpdate_WithEmptyPackageName_ReturnsError()
     {
         // Validates that empty package name returns error
-        var result = await _tools.DotnetToolUpdate(
-            packageName: "");
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Update,
+            packageId: "");
 
         Assert.Contains("Error", result);
-        Assert.Contains("packageName parameter is required", result);
+        Assert.Contains("packageId", result);
+        Assert.Contains("required", result, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public async Task DotnetToolUninstall_WithPackageName_ExecutesCommand()
     {
         // Validates that tool uninstall with package name works
-        var result = await _tools.DotnetToolUninstall(
-            packageName: "dotnet-ef");
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Uninstall,
+            packageId: "dotnet-ef");
 
         Assert.NotNull(result);
     }
@@ -526,8 +542,9 @@ public class DotNetCliToolsTests
     public async Task DotnetToolUninstall_WithGlobalFlag_ExecutesCommand()
     {
         // Validates that global tool uninstall works
-        var result = await _tools.DotnetToolUninstall(
-            packageName: "dotnet-ef",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Uninstall,
+            packageId: "dotnet-ef",
             global: true);
 
         Assert.NotNull(result);
@@ -537,18 +554,20 @@ public class DotNetCliToolsTests
     public async Task DotnetToolUninstall_WithEmptyPackageName_ReturnsError()
     {
         // Validates that empty package name returns error
-        var result = await _tools.DotnetToolUninstall(
-            packageName: "");
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Uninstall,
+            packageId: "");
 
         Assert.Contains("Error", result);
-        Assert.Contains("packageName parameter is required", result);
+        Assert.Contains("packageId", result);
+        Assert.Contains("required", result, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public async Task DotnetToolRestore_ExecutesCommand()
     {
         // Validates that tool restore command works
-        var result = await _tools.DotnetToolRestore();
+        var result = await _tools.DotnetTool(action: DotNetMcp.Actions.DotnetToolAction.Restore);
 
         Assert.NotNull(result);
     }
@@ -562,7 +581,8 @@ public class DotNetCliToolsTests
 
         try
         {
-            var result = await _tools.DotnetToolManifestCreate(
+            var result = await _tools.DotnetTool(
+                action: DotNetMcp.Actions.DotnetToolAction.CreateManifest,
                 output: tempDirectory,
                 machineReadable: true);
 
@@ -585,7 +605,8 @@ public class DotNetCliToolsTests
 
         try
         {
-            var result = await _tools.DotnetToolManifestCreate(
+            var result = await _tools.DotnetTool(
+                action: DotNetMcp.Actions.DotnetToolAction.CreateManifest,
                 output: tempDirectory,
                 machineReadable: true);
 
@@ -608,7 +629,8 @@ public class DotNetCliToolsTests
 
         try
         {
-            var result = await _tools.DotnetToolManifestCreate(
+            var result = await _tools.DotnetTool(
+                action: DotNetMcp.Actions.DotnetToolAction.CreateManifest,
                 output: tempDirectory,
                 force: true,
                 machineReadable: true);
@@ -632,7 +654,8 @@ public class DotNetCliToolsTests
 
         try
         {
-            var result = await _tools.DotnetToolManifestCreate(
+            var result = await _tools.DotnetTool(
+                action: DotNetMcp.Actions.DotnetToolAction.CreateManifest,
                 output: tempDirectory,
                 force: true,
                 machineReadable: true);
@@ -651,7 +674,8 @@ public class DotNetCliToolsTests
     public async Task DotnetToolSearch_WithSearchTerm_ExecutesCommand()
     {
         // Validates that tool search with search term works
-        var result = await _tools.DotnetToolSearch(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Search,
             searchTerm: "entity");
 
         Assert.NotNull(result);
@@ -661,7 +685,8 @@ public class DotNetCliToolsTests
     public async Task DotnetToolSearch_WithDetail_ExecutesCommand()
     {
         // Validates that tool search with detail flag works
-        var result = await _tools.DotnetToolSearch(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Search,
             searchTerm: "entity",
             detail: true);
 
@@ -672,7 +697,8 @@ public class DotNetCliToolsTests
     public async Task DotnetToolSearch_WithTakeAndSkip_ExecutesCommand()
     {
         // Validates that tool search with pagination works
-        var result = await _tools.DotnetToolSearch(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Search,
             searchTerm: "entity",
             take: 10,
             skip: 5);
@@ -684,7 +710,8 @@ public class DotNetCliToolsTests
     public async Task DotnetToolSearch_WithPrerelease_ExecutesCommand()
     {
         // Validates that tool search with prerelease flag works
-        var result = await _tools.DotnetToolSearch(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Search,
             searchTerm: "entity",
             prerelease: true);
 
@@ -695,7 +722,8 @@ public class DotNetCliToolsTests
     public async Task DotnetToolSearch_WithAllParameters_ExecutesCommand()
     {
         // Validates that all parameters work together
-        var result = await _tools.DotnetToolSearch(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Search,
             searchTerm: "entity",
             detail: true,
             take: 10,
@@ -709,18 +737,21 @@ public class DotNetCliToolsTests
     public async Task DotnetToolSearch_WithEmptySearchTerm_ReturnsError()
     {
         // Validates that empty search term returns error
-        var result = await _tools.DotnetToolSearch(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Search,
             searchTerm: "");
 
         Assert.Contains("Error", result);
-        Assert.Contains("searchTerm parameter is required", result);
+        Assert.Contains("searchTerm", result);
+        Assert.Contains("required", result, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public async Task DotnetToolRun_WithToolName_ExecutesCommand()
     {
         // Validates that tool run with tool name works
-        var result = await _tools.DotnetToolRun(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Run,
             toolName: "dotnet-ef");
 
         Assert.NotNull(result);
@@ -730,7 +761,8 @@ public class DotNetCliToolsTests
     public async Task DotnetToolRun_WithArgs_ExecutesCommand()
     {
         // Validates that tool run with arguments works
-        var result = await _tools.DotnetToolRun(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Run,
             toolName: "dotnet-ef",
             args: "migrations add Initial");
 
@@ -741,18 +773,21 @@ public class DotNetCliToolsTests
     public async Task DotnetToolRun_WithEmptyToolName_ReturnsError()
     {
         // Validates that empty tool name returns error
-        var result = await _tools.DotnetToolRun(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Run,
             toolName: "");
 
         Assert.Contains("Error", result);
-        Assert.Contains("toolName parameter is required", result);
+        Assert.Contains("toolName", result);
+        Assert.Contains("required", result, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public async Task DotnetToolRun_WithInvalidArgsCharacters_ReturnsError()
     {
         // Validates that args with shell metacharacters returns error
-        var result = await _tools.DotnetToolRun(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Run,
             toolName: "dotnet-ef",
             args: "migrations add Initial && echo hacked");
 

--- a/DotNetMcp.Tests/Tools/EdgeCaseAndIntegrationTests.cs
+++ b/DotNetMcp.Tests/Tools/EdgeCaseAndIntegrationTests.cs
@@ -111,8 +111,9 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetPackageAdd_WithAllParameters_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetPackageAdd(
-            packageName: "Microsoft.Extensions.Logging",
+        var result = await _tools.DotnetPackage(
+            action: DotNetMcp.Actions.DotnetPackageAction.Add,
+            packageId: "Microsoft.Extensions.Logging",
             project: "MyProject.csproj",
             version: "8.0.0",
             prerelease: false,
@@ -127,7 +128,8 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetPackageList_WithAllParameters_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetPackageList(
+        var result = await _tools.DotnetPackage(
+            action: DotNetMcp.Actions.DotnetPackageAction.List,
             project: "MyProject.csproj",
             outdated: true,
             deprecated: true,
@@ -144,7 +146,8 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetSolutionCreate_WithMachineReadable_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetSolutionCreate(
+        var result = await _tools.DotnetSolution(
+            action: DotNetMcp.Actions.DotnetSolutionAction.Create,
             name: "TestSolution",
             machineReadable: true);
 
@@ -284,8 +287,9 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetToolInstall_WithMachineReadable_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetToolInstall(
-            packageName: "dotnet-format",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Install,
+            packageId: "dotnet-format",
             global: true,
             machineReadable: true);
 
@@ -298,7 +302,8 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetToolList_WithMachineReadable_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetToolList(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.List,
             global: true,
             machineReadable: true);
 
@@ -311,8 +316,9 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetToolUpdate_WithMachineReadable_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetToolUpdate(
-            packageName: "dotnet-ef",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Update,
+            packageId: "dotnet-ef",
             global: true,
             version: "8.0.0",
             machineReadable: true);
@@ -326,8 +332,9 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetToolUninstall_WithMachineReadable_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetToolUninstall(
-            packageName: "dotnet-format",
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Uninstall,
+            packageId: "dotnet-format",
             global: false,
             machineReadable: true);
 
@@ -340,7 +347,9 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetToolRestore_WithMachineReadable_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetToolRestore(machineReadable: true);
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Restore,
+            machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -357,7 +366,8 @@ public class EdgeCaseAndIntegrationTests
         string result;
         try
         {
-            result = await _tools.DotnetToolManifestCreate(
+            result = await _tools.DotnetTool(
+                action: DotNetMcp.Actions.DotnetToolAction.CreateManifest,
                 output: tempDirectory.FullName,
                 force: true,
                 machineReadable: true);
@@ -377,7 +387,8 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetToolSearch_WithMachineReadable_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetToolSearch(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Search,
             searchTerm: "format",
             detail: true,
             take: 5,
@@ -394,7 +405,8 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetToolRun_WithMachineReadable_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetToolRun(
+        var result = await _tools.DotnetTool(
+            action: DotNetMcp.Actions.DotnetToolAction.Run,
             toolName: "dotnet-ef",
             args: "database update",
             machineReadable: true);
@@ -410,7 +422,9 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetFrameworkInfo_WithNetStandard_ReturnsCorrectInformation()
     {
         // Act
-        var result = await _tools.DotnetFrameworkInfo(framework: "netstandard2.1");
+        var result = await _tools.DotnetSdk(
+            action: DotNetMcp.Actions.DotnetSdkAction.FrameworkInfo,
+            framework: "netstandard2.1");
 
         // Assert
         Assert.NotNull(result);
@@ -422,7 +436,9 @@ public class EdgeCaseAndIntegrationTests
     public async Task DotnetFrameworkInfo_WithModernNet_ReturnsCorrectInformation()
     {
         // Act
-        var result = await _tools.DotnetFrameworkInfo(framework: "net10.0");
+        var result = await _tools.DotnetSdk(
+            action: DotNetMcp.Actions.DotnetSdkAction.FrameworkInfo,
+            framework: "net10.0");
 
         // Assert
         Assert.NotNull(result);

--- a/DotNetMcp.Tests/Tools/MachineReadableOutputTests.cs
+++ b/DotNetMcp.Tests/Tools/MachineReadableOutputTests.cs
@@ -23,7 +23,7 @@ public class MachineReadableOutputTests
     public async Task DotnetSdkVersion_WithMachineReadableFalse_ReturnsPlainText()
     {
         // Act
-        var result = await _tools.DotnetSdkVersion(machineReadable: false);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Version, machineReadable: false);
 
         // Assert
         Assert.NotNull(result);
@@ -39,7 +39,7 @@ public class MachineReadableOutputTests
     public async Task DotnetSdkVersion_WithMachineReadableTrue_ReturnsValidJson()
     {
         // Act
-        var result = await _tools.DotnetSdkVersion(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Version, machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -73,7 +73,8 @@ public class MachineReadableOutputTests
         var nonExistentProject = "/tmp/NonExistent_Project_12345.csproj";
 
         // Act
-        var result = await _tools.DotnetProjectBuild(
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Build,
             project: nonExistentProject,
             machineReadable: true);
 
@@ -100,7 +101,8 @@ public class MachineReadableOutputTests
     public async Task DotnetPackageSearch_WithMachineReadableTrue_ReturnsValidJson()
     {
         // Act
-        var result = await _tools.DotnetPackageSearch(
+        var result = await _tools.DotnetPackage(
+            action: DotNetMcp.Actions.DotnetPackageAction.Search,
             searchTerm: "Newtonsoft.Json",
             take: 1,
             machineReadable: true);
@@ -117,7 +119,8 @@ public class MachineReadableOutputTests
     public async Task DotnetProjectNew_WithMachineReadableFalse_ReturnsPlainTextByDefault()
     {
         // Act - using default machineReadable parameter (should be false)
-        var result = await _tools.DotnetProjectNew(
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.New,
             template: "console",
             name: "TestApp",
             output: "/tmp/test-output-" + Guid.NewGuid());
@@ -134,13 +137,13 @@ public class MachineReadableOutputTests
     [Fact]
     public async Task MachineReadableParameter_DefaultsToFalse_ForBackwardsCompatibility()
     {
-        // This test verifies that existing code calling methods without machineReadable
-        // parameter continues to work and returns plain text
+        // This test verifies that calling consolidated tools without machineReadable
+        // continues to return plain text
 
         // Act - call without machineReadable parameter
-        var sdkInfoResult = await _tools.DotnetSdkInfo();
-        var sdkListResult = await _tools.DotnetSdkList();
-        var runtimeListResult = await _tools.DotnetRuntimeList();
+        var sdkInfoResult = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Info);
+        var sdkListResult = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.ListSdks);
+        var runtimeListResult = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.ListRuntimes);
 
         // Assert - all should return plain text (not JSON)
         var results = new[] { sdkInfoResult, sdkListResult, runtimeListResult };

--- a/DotNetMcp.Tests/Tools/MiscellaneousToolsTests.cs
+++ b/DotNetMcp.Tests/Tools/MiscellaneousToolsTests.cs
@@ -46,7 +46,9 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchRun_WithoutParameters_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchRun();
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "run");
 
         // Assert
         Assert.NotNull(result);
@@ -58,7 +60,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchRun_WithProject_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchRun(project: "MyProject.csproj");
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "run",
+            project: "MyProject.csproj");
 
         // Assert
         Assert.NotNull(result);
@@ -70,7 +75,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchRun_WithAppArgs_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchRun(appArgs: "--environment Development");
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "run",
+            appArgs: "--environment Development");
 
         // Assert
         Assert.NotNull(result);
@@ -82,7 +90,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchRun_WithNoHotReload_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchRun(noHotReload: true);
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "run",
+            noHotReload: true);
 
         // Assert
         Assert.NotNull(result);
@@ -94,7 +105,9 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchTest_WithoutParameters_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchTest();
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "test");
 
         // Assert
         Assert.NotNull(result);
@@ -107,7 +120,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchTest_WithProject_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchTest(project: "MyTests.csproj");
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "test",
+            project: "MyTests.csproj");
 
         // Assert
         Assert.NotNull(result);
@@ -119,7 +135,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchTest_WithFilter_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchTest(filter: "FullyQualifiedName~MyTest");
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "test",
+            filter: "FullyQualifiedName~MyTest");
 
         // Assert
         Assert.NotNull(result);
@@ -131,7 +150,9 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchBuild_WithoutParameters_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchBuild();
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "build");
 
         // Assert
         Assert.NotNull(result);
@@ -144,7 +165,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchBuild_WithProject_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchBuild(project: "MyProject.csproj");
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "build",
+            project: "MyProject.csproj");
 
         // Assert
         Assert.NotNull(result);
@@ -156,7 +180,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetWatchBuild_WithConfiguration_ReturnsWarning()
     {
         // Act
-        var result = await _tools.DotnetWatchBuild(configuration: "Release");
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Watch,
+            watchAction: "build",
+            configuration: "Release");
 
         // Assert
         Assert.NotNull(result);
@@ -170,7 +197,9 @@ public class MiscellaneousToolsTests
     public async Task DotnetFormat_WithoutParameters_BuildsCorrectCommand()
     {
         // Act
-        var result = await ExecuteInTempDirectoryAsync(() => _tools.DotnetFormat(machineReadable: true));
+        var result = await ExecuteInTempDirectoryAsync(() => _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Format,
+            machineReadable: true));
 
         // Assert
         Assert.NotNull(result);
@@ -181,7 +210,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetFormat_WithProject_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetFormat(project: "MyProject.csproj", machineReadable: true);
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Format,
+            project: "MyProject.csproj",
+            machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -192,7 +224,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetFormat_WithVerify_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetFormat(verify: true, machineReadable: true);
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Format,
+            verify: true,
+            machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -203,7 +238,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetFormat_WithIncludeGenerated_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetFormat(includeGenerated: true, machineReadable: true);
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Format,
+            includeGenerated: true,
+            machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -214,7 +252,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetFormat_WithDiagnostics_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetFormat(diagnostics: "IDE0005,CA1304", machineReadable: true);
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Format,
+            diagnostics: "IDE0005,CA1304",
+            machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -225,7 +266,10 @@ public class MiscellaneousToolsTests
     public async Task DotnetFormat_WithSeverity_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetFormat(severity: "warn", machineReadable: true);
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Format,
+            severity: "warn",
+            machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -236,7 +280,8 @@ public class MiscellaneousToolsTests
     public async Task DotnetFormat_WithAllParameters_BuildsCorrectCommand()
     {
         // Act
-        var result = await _tools.DotnetFormat(
+        var result = await _tools.DotnetProject(
+            action: DotNetMcp.Actions.DotnetProjectAction.Format,
             project: "MyProject.csproj",
             verify: true,
             includeGenerated: true,
@@ -384,7 +429,7 @@ public class MiscellaneousToolsTests
     public async Task DotnetFrameworkInfo_WithoutParameters_ReturnsFrameworkList()
     {
         // Act
-        var result = await _tools.DotnetFrameworkInfo();
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.FrameworkInfo);
 
         // Assert
         Assert.NotNull(result);
@@ -400,7 +445,7 @@ public class MiscellaneousToolsTests
     public async Task DotnetFrameworkInfo_WithSpecificFramework_ReturnsFrameworkDetails()
     {
         // Act
-        var result = await _tools.DotnetFrameworkInfo(framework: "net8.0");
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.FrameworkInfo, framework: "net8.0");
 
         // Assert
         Assert.NotNull(result);
@@ -414,7 +459,7 @@ public class MiscellaneousToolsTests
     public async Task DotnetFrameworkInfo_WithLegacyFramework_ReturnsFrameworkDetails()
     {
         // Act
-        var result = await _tools.DotnetFrameworkInfo(framework: "netcoreapp3.1");
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.FrameworkInfo, framework: "netcoreapp3.1");
 
         // Assert
         Assert.NotNull(result);

--- a/DotNetMcp.Tests/Tools/SdkAndServerInfoToolsTests.cs
+++ b/DotNetMcp.Tests/Tools/SdkAndServerInfoToolsTests.cs
@@ -25,7 +25,7 @@ public class SdkAndServerInfoToolsTests
     public async Task DotnetSdkInfo_ReturnsSDKInformation()
     {
         // Act
-        var result = await _tools.DotnetSdkInfo();
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Info);
 
         // Assert
         Assert.NotNull(result);
@@ -41,7 +41,7 @@ public class SdkAndServerInfoToolsTests
     public async Task DotnetSdkInfo_WithMachineReadable_ReturnsStructuredOutput()
     {
         // Act
-        var result = await _tools.DotnetSdkInfo(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Info, machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -52,7 +52,7 @@ public class SdkAndServerInfoToolsTests
     public async Task DotnetSdkVersion_ReturnsSDKVersion()
     {
         // Act
-        var result = await _tools.DotnetSdkVersion();
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Version);
 
         // Assert
         Assert.NotNull(result);
@@ -65,7 +65,7 @@ public class SdkAndServerInfoToolsTests
     public async Task DotnetSdkVersion_WithMachineReadable_ReturnsStructuredOutput()
     {
         // Act
-        var result = await _tools.DotnetSdkVersion(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.Version, machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -76,7 +76,7 @@ public class SdkAndServerInfoToolsTests
     public async Task DotnetSdkList_ReturnsInstalledSDKs()
     {
         // Act
-        var result = await _tools.DotnetSdkList();
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.ListSdks);
 
         // Assert
         Assert.NotNull(result);
@@ -92,7 +92,7 @@ public class SdkAndServerInfoToolsTests
     public async Task DotnetSdkList_WithMachineReadable_ReturnsStructuredOutput()
     {
         // Act
-        var result = await _tools.DotnetSdkList(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.ListSdks, machineReadable: true);
 
         // Assert
         Assert.NotNull(result);
@@ -103,7 +103,7 @@ public class SdkAndServerInfoToolsTests
     public async Task DotnetRuntimeList_ReturnsInstalledRuntimes()
     {
         // Act
-        var result = await _tools.DotnetRuntimeList();
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.ListRuntimes);
 
         // Assert
         Assert.NotNull(result);
@@ -119,7 +119,7 @@ public class SdkAndServerInfoToolsTests
     public async Task DotnetRuntimeList_WithMachineReadable_ReturnsStructuredOutput()
     {
         // Act
-        var result = await _tools.DotnetRuntimeList(machineReadable: true);
+        var result = await _tools.DotnetSdk(action: DotNetMcp.Actions.DotnetSdkAction.ListRuntimes, machineReadable: true);
 
         // Assert
         Assert.NotNull(result);

--- a/DotNetMcp/DotNetCliTools.cs
+++ b/DotNetMcp/DotNetCliTools.cs
@@ -3,7 +3,7 @@ namespace DotNetMcp;
 /// <summary>
 /// Tool methods for .NET CLI operations. This is a partial class split across multiple files.
 /// All tool methods are implemented in the Tools/ directory partial class files.
-/// See Tools/DotNetCliTools.Core.cs for class infrastructure.
+/// See Tools/Cli/DotNetCliTools.Core.cs for class infrastructure.
 /// </summary>
 public sealed partial class DotNetCliTools
 {
@@ -11,20 +11,22 @@ public sealed partial class DotNetCliTools
     // All functionality is implemented in partial class files in the Tools/ directory:
     //
     // Core infrastructure:
-    //   - Tools/DotNetCliTools.Core.cs - Fields, constructor, helper methods
+    //   - Tools/Cli/DotNetCliTools.Core.cs - Fields, constructor, helper methods
     //
-    // Tool categories:
-    //   - Tools/DotNetCliTools.Template.cs - Template discovery and management
-    //   - Tools/DotNetCliTools.Sdk.cs - SDK and framework information
-    //   - Tools/DotNetCliTools.Package.cs - NuGet package operations
-    //   - Tools/DotNetCliTools.Reference.cs - Project references
-    //   - Tools/DotNetCliTools.Watch.cs - File watching operations
-    //   - Tools/DotNetCliTools.Solution.cs - Solution file management
-    //   - Tools/DotNetCliTools.Tool.cs - Tool management
-    //   - Tools/DotNetCliTools.Workload.cs - Workload management (mobile, MAUI, WASM)
-    //   - Tools/DotNetCliTools.Security.cs - Certificates and user secrets
-    //   - Tools/DotNetCliTools.EntityFramework.cs - Entity Framework Core
-    //   - Tools/DotNetCliTools.Project.cs - Project operations
-    //   - Tools/DotNetCliTools.Misc.cs - Help, server info, and formatting
+    // Consolidated tool entrypoints are implemented under Tools/Cli and Tools/Sdk.
+    // Helper methods used by consolidated tools live alongside them.
+    //
+    // Tools/Cli:
+    //   - DotNetCliTools.Project.Consolidated.cs
+    //   - DotNetCliTools.Package.Consolidated.cs
+    //   - DotNetCliTools.Solution.cs
+    //   - DotNetCliTools.Tool.Consolidated.cs
+    //   - DotNetCliTools.Workload.Consolidated.cs
+    //   - DotNetCliTools.DevCerts.Consolidated.cs
+    //   - DotNetCliTools.EntityFramework.Consolidated.cs
+    //   - DotNetCliTools.Misc.cs
+    //
+    // Tools/Sdk:
+    //   - DotNetCliTools.Sdk.Consolidated.cs
 }
 

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Misc.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Misc.cs
@@ -143,7 +143,7 @@ public sealed partial class DotNetCliTools
         result.AppendLine("  • SDK Info: 5-minute TTL, thread-safe with metrics");
         result.AppendLine("  • Runtime Info: 5-minute TTL, thread-safe with metrics");
         result.AppendLine("  • Force reload available on template tools");
-        result.AppendLine("  • Use dotnet_cache_metrics for hit/miss statistics");
+        result.AppendLine("  • Use dotnet_sdk (action: CacheMetrics) for hit/miss statistics");
         result.AppendLine();
 
         result.AppendLine("RESOURCES (Read-Only Access):");
@@ -176,10 +176,7 @@ public sealed partial class DotNetCliTools
     /// <param name="diagnostics">Comma-separated list of diagnostic IDs to fix</param>
     /// <param name="severity">Severity level to fix (info, warn, error)</param>
     /// <param name="machineReadable">Return structured JSON output for both success and error responses instead of plain text</param>
-    [McpMeta("category", "format")]
-    [McpMeta("priority", 6.0)]
-    [McpMeta("minimumSdkVersion", "6.0")]
-    public async Task<string> DotnetFormat(
+    internal async Task<string> DotnetFormat(
         string? project = null,
         bool verify = false,
         bool includeGenerated = false,

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Solution.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Solution.cs
@@ -16,11 +16,7 @@ public sealed partial class DotNetCliTools
     /// <param name="output">The output directory for the solution file</param>
     /// <param name="format">The solution file format: 'sln' (classic) or 'slnx' (XML-based). Default is 'sln'.</param>
     /// <param name="machineReadable">Return structured JSON output for both success and error responses instead of plain text</param>
-    [McpMeta("category", "solution")]
-    [McpMeta("priority", 8.0)]
-    [McpMeta("commonlyUsed", true)]
-    [McpMeta("tags", JsonValue = """["solution","create","new","organization","multi-project"]""")]
-    public async Task<string> DotnetSolutionCreate(
+    internal async Task<string> DotnetSolutionCreate(
         string name,
         string? output = null,
         string? format = null,
@@ -54,9 +50,7 @@ public sealed partial class DotNetCliTools
     /// <param name="solution">The solution file to add projects to</param>
     /// <param name="projects">Array of project file paths to add to the solution</param>
     /// <param name="machineReadable">Return structured JSON output for both success and error responses instead of plain text</param>
-    [McpMeta("category", "solution")]
-    [McpMeta("priority", 7.0)]
-    public async Task<string> DotnetSolutionAdd(
+    internal async Task<string> DotnetSolutionAdd(
         string solution,
         string[] projects,
         bool machineReadable = false)
@@ -87,9 +81,7 @@ public sealed partial class DotNetCliTools
     /// </summary>
     /// <param name="solution">The solution file to list projects from</param>
     /// <param name="machineReadable">Return structured JSON output for both success and error responses instead of plain text</param>
-    [McpMeta("category", "solution")]
-    [McpMeta("priority", 6.0)]
-    public async Task<string> DotnetSolutionList(
+    internal async Task<string> DotnetSolutionList(
         string solution,
         bool machineReadable = false)
         => await ExecuteDotNetCommand($"solution \"{solution}\" list", machineReadable);
@@ -100,9 +92,7 @@ public sealed partial class DotNetCliTools
     /// <param name="solution">The solution file to remove projects from</param>
     /// <param name="projects">Array of project file paths to remove from the solution</param>
     /// <param name="machineReadable">Return structured JSON output for both success and error responses instead of plain text</param>
-    [McpMeta("category", "solution")]
-    [McpMeta("priority", 5.0)]
-    public async Task<string> DotnetSolutionRemove(
+    internal async Task<string> DotnetSolutionRemove(
         string solution,
         string[] projects,
         bool machineReadable = false)

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Tool.Consolidated.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Tool.Consolidated.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Text;
 using DotNetMcp.Actions;
 using ModelContextProtocol.Server;
@@ -33,13 +32,12 @@ public sealed partial class DotNetCliTools
     /// <param name="workingDirectory">Working directory for command execution</param>
     /// <param name="machineReadable">Return structured JSON output for both success and error responses instead of plain text</param>
     [McpServerTool]
-    [Description("Manage .NET tools (global, local, and tool manifests). Supports install, list, update, uninstall, restore, search, run, and manifest creation.")]
     [McpMeta("category", "tool")]
     [McpMeta("priority", 9.0)]
     [McpMeta("commonlyUsed", true)]
     [McpMeta("consolidatedTool", true)]
     [McpMeta("actions", JsonValue = """["Install","List","Update","Uninstall","Restore","CreateManifest","Search","Run"]""")]
-    internal async Task<string> DotnetTool(
+    public async partial Task<string> DotnetTool(
         DotnetToolAction action,
         string? packageId = null,
         bool? global = null,

--- a/DotNetMcp/Tools/Sdk/DotNetCliTools.Sdk.Consolidated.cs
+++ b/DotNetMcp/Tools/Sdk/DotNetCliTools.Sdk.Consolidated.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -23,13 +22,12 @@ public sealed partial class DotNetCliTools
     /// <param name="workingDirectory">Working directory for command execution</param>
     /// <param name="machineReadable">Return structured JSON output for both success and error responses instead of plain text</param>
     [McpServerTool]
-    [Description("Query .NET SDK, runtime, template, and framework information. Supports version info, SDK/runtime listing, template operations, framework metadata, and cache metrics.")]
     [McpMeta("category", "sdk")]
     [McpMeta("priority", 9.0)]
     [McpMeta("commonlyUsed", true)]
     [McpMeta("consolidatedTool", true)]
     [McpMeta("actions", JsonValue = """["Version","Info","ListSdks","ListRuntimes","ListTemplates","SearchTemplates","TemplateInfo","ClearTemplateCache","FrameworkInfo","CacheMetrics"]""")]
-    internal async Task<string> DotnetSdk(
+    public async partial Task<string> DotnetSdk(
         DotnetSdkAction action,
         string? searchTerm = null,
         string? templateShortName = null,
@@ -58,7 +56,7 @@ public sealed partial class DotNetCliTools
             // Route to appropriate handler based on action
             return action switch
             {
-                // Use executor directly so workingDirectory is honored without changing legacy tool signatures
+                // Use executor directly so workingDirectory is honored without changing helper method signatures
                 DotnetSdkAction.Version => await ExecuteDotNetCommand("--version", machineReadable),
                 DotnetSdkAction.Info => await ExecuteDotNetCommand("--info", machineReadable),
                 DotnetSdkAction.ListSdks => await ExecuteDotNetCommand("--list-sdks", machineReadable),


### PR DESCRIPTION
This refactor tightens the consolidated/composite tool surface so the consolidated entrypoints are the primary public API and tests exercise that surface.

Changes
- Normalize consolidated entrypoints: `dotnet_sdk` and `dotnet_tool` are `public partial` and rely on XML docs (removed legacy `[Description]`).
- Reduce “tool-like” helper exposure: keep helpers internal and remove tool-like metadata where applicable.
- Fix minor server-info/comment drift to match consolidated naming.
- Migrate tests to consolidated entrypoints (`dotnet_sdk`, `dotnet_project`, `dotnet_package`, `dotnet_tool`, `dotnet_solution`).

Validation
- `dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj -c Release`