### PR TITLE
Enhance workflow to run both Scenario and Release Scenario tests

### DIFF
--- a/.github/workflows/release-scenarios.yml
+++ b/.github/workflows/release-scenarios.yml
@@ -53,5 +53,7 @@ jobs:
             - name: Validate server.json
               run: pwsh -File scripts/validate-server-json.ps1
 
-            - name: Run Release Scenario Tests
-              run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-namespace "*DotNetMcp.Tests.ReleaseScenarios*"
+            - name: Run Scenario + Release Scenario Tests
+              run: |
+                  dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-namespace "*DotNetMcp.Tests.Scenarios*"
+                  dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-namespace "*DotNetMcp.Tests.ReleaseScenarios*"


### PR DESCRIPTION
This pull request updates the workflow for running tests in the `.github/workflows/release-scenarios.yml` file. The main change is that the workflow now runs both the general scenario tests and the release scenario tests, instead of just the release scenario tests.

Testing workflow improvements:

* Updated the test step to run both `*DotNetMcp.Tests.Scenarios*` and `*DotNetMcp.Tests.ReleaseScenarios*` test namespaces, ensuring broader test coverage during the release workflow.