### PR TITLE
Docs: add release checklists and helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ Key files to start with:
 - 📖 [Tool Surface Consolidation](doc/tool-surface-consolidation.md) - **Consolidated tool design and architecture**
 - 📖 [SDK Integration Details](doc/sdk-integration.md) - Technical architecture and SDK usage
 - 📖 [Advanced Topics](doc/advanced-topics.md) - Performance, logging, and security details
+- 📖 [Releasing](doc/releasing.md) - How to cut a release (checklists + scripts)
 - 📖 [Concurrency Safety](doc/concurrency.md) - Parallel execution guidance for AI orchestrators
 - 📖 [Testing](doc/testing.md) - How to run tests (including opt-in interactive tests)
 - 📖 [Model Context Protocol](https://modelcontextprotocol.io/) - Official MCP specification

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -1,0 +1,163 @@
+# Releasing
+
+This repo uses **tag-driven releases**.
+
+- The publish workflow runs from a version tag (for example: `v1.0.2`).
+- The most common release mistake is tagging the wrong commit (often from a stale GitHub tab or a non-main branch).
+
+## Golden Rule
+
+Create the tag from the exact commit you intend to ship (usually the merge commit on `main`).
+
+If you only remember one verification step, use this one:
+
+```bash
+git branch -r --contains v1.0.2
+```
+
+You should see `origin/main` in the output.
+
+## Release notes
+
+Recommended approach: keep the **authoritative release notes in the GitHub Release body**.
+
+- This avoids having to commit versioned markdown files just to cut a release.
+- A Git tag is the immutable “what code shipped” pointer; a GitHub Release is the editable “what changed” narrative.
+
+There are two good workflows:
+
+### Option A: Generate, then edit (fastest)
+
+1) Tag + push.
+2) Create a **draft** GitHub Release with generated notes.
+3) Edit the notes in the GitHub UI, then publish.
+
+Example:
+
+```bash
+git tag -a v1.0.2 -m "v1.0.2"
+git push origin v1.0.2
+gh release create v1.0.2 --draft --generate-notes
+```
+
+### Option B: Curate locally, but don’t commit (more control)
+
+If you like writing notes in your editor, keep a local file that is **not committed** (for example under `temp/` or `artifacts-local/`) and pass it to `gh`.
+
+Example:
+
+```bash
+gh release create v1.0.2 --draft --notes-file temp/release-notes/v1.0.2.md
+```
+
+If you do want a long-running, in-repo history, use [CHANGELOG.md](../CHANGELOG.md) as the curated archive and keep the GitHub Release body as the “announcement” view.
+
+## Checklist (Command Line - recommended)
+
+### 1) Preflight
+
+- `git fetch --tags origin`
+- `git switch main`
+- `git pull --ff-only`
+- `git status -sb` (must be clean)
+- Confirm the commit you plan to release:
+  - `git log -1 --oneline`
+
+Optional but recommended:
+
+- `dotnet build --project DotNetMcp/DotNetMcp.csproj`
+- `dotnet test --solution DotNetMcp.slnx`
+
+### 2) Create an annotated tag
+
+Annotated tags add useful audit info (who/when/message).
+
+```bash
+git tag -a v1.0.2 -m "v1.0.2"
+```
+
+### 3) Verify the tag points to the right place
+
+```bash
+git show -s --format="%H %s" v1.0.2
+git branch -r --contains v1.0.2
+```
+
+### 4) Push the tag
+
+```bash
+git push origin v1.0.2
+```
+
+### 5) Create the GitHub Release (notes)
+
+Create the release after the tag exists on GitHub.
+
+```bash
+gh release create v1.0.2 --generate-notes
+```
+
+Or, if you have a notes file:
+
+```bash
+gh release create v1.0.2 --notes-file artifacts/release-notes/v1.0.2.md
+```
+
+### 6) Watch the publish workflow
+
+- GitHub Actions should run on the tag.
+- Confirm the publish run is using the tagged SHA.
+
+## Checklist (GitHub Web UI)
+
+The web UI is convenient, but it’s easier to accidentally tag the wrong commit (especially if the page was opened days ago).
+
+### 1) Avoid stale UI state
+
+- Do a hard refresh right before creating the release: `Ctrl+F5`
+
+### 2) Explicitly select the target branch
+
+- When creating the release, explicitly set **Target** to `main`.
+- Do not trust whatever value is pre-selected.
+
+### 3) Confirm the commit preview
+
+- The “recent commits” preview should show the merge commit you expect.
+- If it mentions a Dependabot branch or any non-main branch name, stop.
+
+### 4) Create the tag + release
+
+- Prefer creating a **draft release** first.
+- Double-check: **Tag**, **Target**, and **commit preview**.
+- Publish.
+
+### 5) Sanity check after publish
+
+- NuGet package exists for the version.
+- MCP registry shows the new version.
+- Install docs/badges still point at the intended floating major (`@1.*`).
+
+## PowerShell helper (optional)
+
+See `scripts/cut-release.ps1` for a safe “tag + verify + push (+ optional GitHub release)” helper.
+
+Examples:
+
+```powershell
+# Dry-run (no changes), validates preflight checks
+./scripts/cut-release.ps1 -Version 1.0.2 -WhatIf
+
+# Create + push annotated tag
+./scripts/cut-release.ps1 -Version 1.0.2
+
+# Create + push tag, then create a draft GitHub Release with generated notes
+./scripts/cut-release.ps1 -Version 1.0.2 -CreateGitHubRelease -Draft -GenerateNotes
+```
+
+It’s designed to be run from the repo root and intentionally refuses to proceed if:
+
+- your working tree is dirty
+- you’re not on `main`
+- `main` can’t be fast-forwarded
+- the tag already exists

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -1,0 +1,163 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Version,
+
+    [switch] $CreateGitHubRelease,
+
+    [switch] $Draft,
+
+    [string] $NotesFile,
+
+    [switch] $GenerateNotes
+)
+
+function Fail([string] $message)
+{
+    throw $message
+}
+
+function Invoke-Git([Parameter(Mandatory = $true)][string[]] $Args)
+{
+    & git @Args
+    if ($LASTEXITCODE -ne 0)
+    {
+        Fail ("git failed: git " + ($Args -join ' '))
+    }
+}
+
+function Invoke-Gh([Parameter(Mandatory = $true)][string[]] $Args)
+{
+    & gh @Args
+    if ($LASTEXITCODE -ne 0)
+    {
+        Fail ("gh failed: gh " + ($Args -join ' '))
+    }
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue))
+{
+    Fail "git is required but was not found on PATH."
+}
+
+if ($CreateGitHubRelease -and -not (Get-Command gh -ErrorAction SilentlyContinue))
+{
+    Fail "gh is required for -CreateGitHubRelease but was not found on PATH."
+}
+
+if ($CreateGitHubRelease)
+{
+    if ($GenerateNotes -and -not [string]::IsNullOrWhiteSpace($NotesFile))
+    {
+        Fail "Specify either -GenerateNotes or -NotesFile (not both)."
+    }
+
+    if (-not $GenerateNotes -and [string]::IsNullOrWhiteSpace($NotesFile))
+    {
+        Write-Host "No release notes option specified; defaulting to -GenerateNotes." -ForegroundColor DarkGray
+        $GenerateNotes = $true
+    }
+}
+
+$normalizedVersion = $Version.Trim()
+if (-not $normalizedVersion.StartsWith('v'))
+{
+    $normalizedVersion = 'v' + $normalizedVersion
+}
+
+if ($normalizedVersion -notmatch '^v\d+\.\d+\.\d+([-.][0-9A-Za-z][0-9A-Za-z.-]*)?$')
+{
+    Fail "Version '$Version' does not look like a semver tag. Expected like v1.2.3 or v1.2.3-rc.1"
+}
+
+Write-Host "Cutting release tag $normalizedVersion" -ForegroundColor Cyan
+
+Invoke-Git @('fetch', '--tags', 'origin')
+
+# Ensure we're on main and up-to-date
+$branch = (& git rev-parse --abbrev-ref HEAD).Trim()
+if ($LASTEXITCODE -ne 0)
+{
+    Fail "Unable to determine current branch."
+}
+
+if ($branch -ne 'main')
+{
+    Fail "Refusing to tag from branch '$branch'. Switch to 'main' first."
+}
+
+Invoke-Git @('pull', '--ff-only')
+
+# Require clean working tree
+$statusPorcelain = (& git status --porcelain).Trim()
+if ($LASTEXITCODE -ne 0)
+{
+    Fail "Unable to read git status."
+}
+
+if (-not [string]::IsNullOrWhiteSpace($statusPorcelain))
+{
+    Fail "Working tree is not clean. Commit/stash changes before cutting a release."
+}
+
+# Refuse if tag already exists
+& git rev-parse -q --verify "refs/tags/$normalizedVersion" | Out-Null
+if ($LASTEXITCODE -eq 0)
+{
+    Fail "Tag '$normalizedVersion' already exists."
+}
+
+$head = (& git rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($head))
+{
+    Fail "Unable to determine HEAD commit."
+}
+
+Write-Host "Will tag main at $head" -ForegroundColor DarkGray
+
+if ($PSCmdlet.ShouldProcess("origin/$normalizedVersion", "Create annotated tag and push"))
+{
+    Invoke-Git @('tag', '-a', $normalizedVersion, '-m', $normalizedVersion)
+
+    Write-Host "Verifying tag containment..." -ForegroundColor DarkGray
+    $contains = (& git branch -r --contains $normalizedVersion) | ForEach-Object { $_.Trim() }
+    if ($LASTEXITCODE -ne 0)
+    {
+        Fail "Unable to verify branch containment for '$normalizedVersion'."
+    }
+
+    if ($contains -notcontains 'origin/main')
+    {
+        Fail "Safety check failed: '$normalizedVersion' is not contained in origin/main. Refusing to push."
+    }
+
+    Invoke-Git @('push', 'origin', $normalizedVersion)
+}
+
+if ($CreateGitHubRelease)
+{
+    $releaseArgs = @('release', 'create', $normalizedVersion)
+
+    if ($Draft)
+    {
+        $releaseArgs += '--draft'
+    }
+
+    if ($GenerateNotes)
+    {
+        $releaseArgs += '--generate-notes'
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($NotesFile))
+    {
+        $releaseArgs += @('--notes-file', $NotesFile)
+    }
+
+    if ($PSCmdlet.ShouldProcess("GitHub release $normalizedVersion", "Create release"))
+    {
+        Invoke-Gh $releaseArgs
+    }
+}
+
+Write-Host "Done." -ForegroundColor Green


### PR DESCRIPTION
This pull request introduces comprehensive documentation and automation for the release process, making it safer and easier to cut releases. The main changes include adding a detailed release guide, a robust PowerShell script to automate tagging and releasing, and updating the documentation index to reference these new resources.

**Release process improvements:**

* Added a new `doc/releasing.md` guide with step-by-step instructions, checklists for both CLI and GitHub UI workflows, and best practices for creating tags, generating release notes, and verifying releases.
* Introduced `scripts/cut-release.ps1`, a PowerShell script that automates the release process with safety checks (verifying branch, clean working tree, tag uniqueness, and correct commit), and supports GitHub release creation with options for draft status and notes generation.

**Documentation updates:**

* Updated the `README.md` to link to the new release guide for easy discoverability.