### PR TITLE
Update NuGet packages (March 2026)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,7 +410,6 @@ FodyWeavers.xsd
 
 # VS Code files for those working on multiple tools
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json

--- a/DotNetMcp.Tests/DotNetMcp.Tests.csproj
+++ b/DotNetMcp.Tests/DotNetMcp.Tests.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DotNetMcp/DotNetMcp.csproj
+++ b/DotNetMcp/DotNetMcp.csproj
@@ -46,11 +46,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="18.3.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.3.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="10.0.103" />
-    <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="10.0.103" />
+    <PackageReference Include="Microsoft.Build" Version="18.4.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="10.0.201" />
+    <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="10.0.201" />
     <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
     <PackageReference Include="MinVer" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Package Updates

| Package | Old | New |
|---------|-----|-----|
| Microsoft.Build | 18.3.3 | 18.4.0 |
| Microsoft.Build.Utilities.Core | 18.3.3 | 18.4.0 |
| Microsoft.Extensions.Hosting | 10.0.3 | 10.0.5 |
| Microsoft.TemplateEngine.Abstractions | 10.0.103 | 10.0.201 |
| Microsoft.TemplateEngine.Edge | 10.0.103 | 10.0.201 |
| Microsoft.Extensions.Logging.Abstractions | 10.0.3 | 10.0.5 |
| Microsoft.Extensions.TimeProvider.Testing | 10.1.0 | 10.4.0 |
| Microsoft.Testing.Extensions.CodeCoverage | 18.1.0 | 18.5.2 |
| xunit.v3.mtp-v2 | 3.2.1 | 3.2.2 |

## Other Changes

- Remove `!.vscode/settings.json` exception from `.gitignore` — personal VS Code config shouldn't be tracked

## Verification

- [x] `dotnet build` succeeds (Release config)
- [ ] CI tests pass