### PR TITLE
Move MCP C# SDK Features section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,23 +65,6 @@ Instead of relying on the LLM to infer state by reading and re-reading console o
 - `machineReadable: true` returns structured JSON (no log scraping)
 - MCP Resources provide lightweight metadata without running commands
 
-### 🧩 **MCP C# SDK Features Used**
-
-dotnet-mcp uses the official [MCP C# SDK](https://csharp.sdk.modelcontextprotocol.io/) and exercises a broad set of MCP features beyond basic tool invocation:
-
-| Feature | How dotnet-mcp uses it | Why |
-| ------- | ---------------------- | --- |
-| [Resources](https://modelcontextprotocol.io/specification/latest/server/resources) | Exposes `dotnet://sdk-info`, `dotnet://runtime-info`, `dotnet://templates`, and `dotnet://frameworks` as read-only MCP resources. | Lets clients answer environment questions quickly without shelling out, and reduces token churn from repeated CLI discovery. |
-| [Prompts](https://modelcontextprotocol.io/specification/latest/server/prompts) | Publishes reusable prompts such as `create_new_webapi`, `add_package_and_restore`, and `run_tests_with_coverage`. | Gives MCP clients guided, discoverable workflows instead of rebuilding common prompt scaffolding from scratch. |
-| [Roots](https://modelcontextprotocol.io/specification/latest/client/roots) | Uses client workspace roots to auto-detect a single project or solution when the user omits an explicit path. | Improves out-of-box behavior in IDE clients and reduces the number of parameters users need to supply. |
-| [Sampling](https://modelcontextprotocol.io/specification/latest/client/sampling) | Requests client-mediated LLM summaries for build and test failures when the client supports sampling. | Keeps intelligent diagnostics inside the MCP flow without requiring separate server-side model credentials. |
-| [Elicitation](https://modelcontextprotocol.io/specification/latest/client/elicitation) | Requests explicit confirmation before destructive actions such as clean and solution removal. | Adds a human-in-the-loop safety check for operations that delete artifacts or mutate project structure. |
-| [Progress notifications](https://modelcontextprotocol.io/specification/latest/basic/utilities/progress) | Reports start/completion progress for long-running restore, build, test, publish, pack, tool, and workload operations. | Gives clients a better UX for slow operations and makes orchestration easier for agents that surface progress. |
-| [Tasks](https://modelcontextprotocol.io/specification/latest/basic/utilities/tasks) | Registers an `IMcpTaskStore` and marks `dotnet_project` with optional task support for long-running operations. | Enables async execution, polling, and cancellation patterns instead of forcing every long-running request to block the session. |
-| [Tools and tool metadata](https://modelcontextprotocol.io/specification/latest/server/tools) | Uses consolidated tools with rich metadata such as titles, categories, priorities, action lists, and task support declarations. | Improves discoverability, routing, and client-side presentation, especially in MCP-aware IDE integrations. |
-| [Prompt and resource completion](https://modelcontextprotocol.io/specification/latest/server/utilities/completion) | Implements a completion handler so clients can autocomplete prompt and resource argument values. | Makes guided workflows faster and reduces invalid argument entry in clients that support completion UX. |
-| [Icons and server metadata](https://csharp.sdk.modelcontextprotocol.io/) | Configures server-level icons plus per-tool `IconSource`, title, and descriptive metadata across the consolidated surface. | Helps clients present the server and tool catalog more clearly, especially in visual MCP management UIs. |
-
 ### 🎯 **Why Not Just Let the AI Call `dotnet` Directly?**
 
 The .NET MCP Server provides **context and intelligence** that raw CLI execution cannot:
@@ -219,9 +202,22 @@ The .NET MCP Server acts as an intelligent middleware that:
 3. **Executes** commands safely with proper error handling
 4. **Returns** structured results that AI assistants can understand and explain
 
-## Testing
+### 🧩 **MCP C# SDK Features Used**
 
-See [doc/testing.md](doc/testing.md) for how to run the test suite, including opt-in scenario tests and long-running release-gate scenarios.
+dotnet-mcp uses the official [MCP C# SDK](https://csharp.sdk.modelcontextprotocol.io/) and exercises a broad set of MCP features beyond basic tool invocation:
+
+| Feature | How dotnet-mcp uses it | Why |
+| ------- | ---------------------- | --- |
+| [Resources](https://modelcontextprotocol.io/specification/latest/server/resources) | Exposes `dotnet://sdk-info`, `dotnet://runtime-info`, `dotnet://templates`, and `dotnet://frameworks` as read-only MCP resources. | Lets clients answer environment questions quickly without shelling out, and reduces token churn from repeated CLI discovery. |
+| [Prompts](https://modelcontextprotocol.io/specification/latest/server/prompts) | Publishes reusable prompts such as `create_new_webapi`, `add_package_and_restore`, and `run_tests_with_coverage`. | Gives MCP clients guided, discoverable workflows instead of rebuilding common prompt scaffolding from scratch. |
+| [Roots](https://modelcontextprotocol.io/specification/latest/client/roots) | Uses client workspace roots to auto-detect a single project or solution when the user omits an explicit path. | Improves out-of-box behavior in IDE clients and reduces the number of parameters users need to supply. |
+| [Sampling](https://modelcontextprotocol.io/specification/latest/client/sampling) | Requests client-mediated LLM summaries for build and test failures when the client supports sampling. | Keeps intelligent diagnostics inside the MCP flow without requiring separate server-side model credentials. |
+| [Elicitation](https://modelcontextprotocol.io/specification/latest/client/elicitation) | Requests explicit confirmation before destructive actions such as clean and solution removal. | Adds a human-in-the-loop safety check for operations that delete artifacts or mutate project structure. |
+| [Progress notifications](https://modelcontextprotocol.io/specification/latest/basic/utilities/progress) | Reports start/completion progress for long-running restore, build, test, publish, pack, tool, and workload operations. | Gives clients a better UX for slow operations and makes orchestration easier for agents that surface progress. |
+| [Tasks](https://modelcontextprotocol.io/specification/latest/basic/utilities/tasks) | Registers an `IMcpTaskStore` and marks `dotnet_project` with optional task support for long-running operations. | Enables async execution, polling, and cancellation patterns instead of forcing every long-running request to block the session. |
+| [Tools and tool metadata](https://modelcontextprotocol.io/specification/latest/server/tools) | Uses consolidated tools with rich metadata such as titles, categories, priorities, action lists, and task support declarations. | Improves discoverability, routing, and client-side presentation, especially in MCP-aware IDE integrations. |
+| [Prompt and resource completion](https://modelcontextprotocol.io/specification/latest/server/utilities/completion) | Implements a completion handler so clients can autocomplete prompt and resource argument values. | Makes guided workflows faster and reduces invalid argument entry in clients that support completion UX. |
+| [Icons and server metadata](https://csharp.sdk.modelcontextprotocol.io/) | Configures server-level icons plus per-tool `IconSource`, title, and descriptive metadata across the consolidated surface. | Helps clients present the server and tool catalog more clearly, especially in visual MCP management UIs. |
 
 ## Installation
 


### PR DESCRIPTION
Move MCP C# SDK features section in README with detailed usage and benefits below the "what it does" section.