### PR TITLE
test: stabilize background-run log scenario

### DIFF
--- a/DotNetMcp.Tests/Scenarios/BackgroundRunScenarioTests.cs
+++ b/DotNetMcp.Tests/Scenarios/BackgroundRunScenarioTests.cs
@@ -6,6 +6,38 @@ namespace DotNetMcp.Tests.Scenarios;
 
 public class BackgroundRunScenarioTests
 {
+    private static async Task<string> WaitForLogsContainingAsync(
+        McpScenarioClient client,
+        string sessionId,
+        string[] expectedFragments,
+        CancellationToken cancellationToken,
+        int timeoutSeconds = 15)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        string? latestLogs = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            latestLogs = await client.CallToolTextAsync(
+                toolName: "dotnet_project",
+                args: new Dictionary<string, object?>
+                {
+                    ["action"] = "Logs",
+                    ["sessionId"] = sessionId,
+                },
+                cancellationToken);
+
+            if (expectedFragments.All(fragment => latestLogs.Contains(fragment, StringComparison.Ordinal)))
+            {
+                return latestLogs;
+            }
+
+            await Task.Delay(250, cancellationToken);
+        }
+
+        return latestLogs ?? string.Empty;
+    }
+
     private static string? ParsePrefixedLine(string text, string prefix)
     {
         var idx = text.IndexOf(prefix, StringComparison.Ordinal);
@@ -181,17 +213,15 @@ Console.WriteLine(""Line 4: Application finished"");
 
         try
         {
-            // Wait a moment for the app to produce output
-            await Task.Delay(2000, cancellationToken);
-
-            // Retrieve logs
-            var logsText = await client.CallToolTextAsync(
-                toolName: "dotnet_project",
-                args: new Dictionary<string, object?>
-                {
-                    ["action"] = "Logs",
-                    ["sessionId"] = sessionId,
-                },
+            var logsText = await WaitForLogsContainingAsync(
+                client,
+                sessionId!,
+                [
+                    "Line 1: Application started",
+                    "Line 2: Initializing...",
+                    "Line 3: Processing...",
+                    "[stderr] Error: This is an error message",
+                ],
                 cancellationToken);
 
             Assert.StartsWith("Logs for session", logsText);


### PR DESCRIPTION
## Summary
Fixes the Ubuntu release-scenarios CI failure by replacing a fixed sleep in the background-run logs scenario with polling for the expected log fragments.

## Problem
The release-scenarios workflow failed in Scenario_BackgroundRun_RetrieveLogs_Success because the test assumed the background process would emit all expected log lines within 2 seconds. On slower CI runners, the process startup and log capture can take longer.

## Change
- add a helper that polls dotnet_project Logs until the expected stdout and stderr fragments are present or a timeout is reached
- use that helper in Scenario_BackgroundRun_RetrieveLogs_Success instead of a fixed Task.Delay(2000)

## Validation
- dotnet build DotNetMcp.slnx --configuration Release
- DOTNET_MCP_SCENARIO_TESTS=1 dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-method *Scenario_BackgroundRun_RetrieveLogs_Success
- DOTNET_MCP_SCENARIO_TESTS=1 dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-namespace *DotNetMcp.Tests.Scenarios*

Related CI run: https://github.com/jongalloway/dotnet-mcp/actions/runs/23210332665/job/67457113307#step:8:33