### PR TITLE
fix: cut-release.ps1 null .Trim() when working tree is clean

### DIFF
--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -91,7 +91,8 @@ if ($branch -ne 'main')
 Invoke-Git @('pull', '--ff-only')
 
 # Require clean working tree
-$statusPorcelain = (& git status --porcelain).Trim()
+$statusPorcelain = (& git status --porcelain) | Out-String
+$statusPorcelain = $statusPorcelain.Trim()
 if ($LASTEXITCODE -ne 0)
 {
     Fail "Unable to read git status."


### PR DESCRIPTION
`git status --porcelain` returns `` (not an empty string) when the working tree is clean, so `.Trim()` throws `You cannot call a method on a null-valued expression`. Pipes through `Out-String` first to guarantee a string value.

Blocks the v1.1.1 release tag.