### PR TITLE
fix: read server version from assembly metadata instead of hardcoded 1.0.0

### DIFF
--- a/DotNetMcp/Program.cs
+++ b/DotNetMcp/Program.cs
@@ -39,7 +39,11 @@ var mcpServerBuilder = builder.Services.AddMcpServer(options =>
     options.ServerInfo = new Implementation
     {
         Name = "dotnet-mcp",
-        Version = "1.0.0",
+        Version = typeof(Program).Assembly.GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+                .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+                .FirstOrDefault()?.InformationalVersion
+            ?? typeof(Program).Assembly.GetName().Version?.ToString()
+            ?? "0.0.0",
         Title = ".NET MCP Server",
         Description = "MCP server providing AI assistants with direct access to the .NET SDK through both official NuGet packages and CLI execution",
         WebsiteUrl = "https://github.com/jongalloway/dotnet-mcp",


### PR DESCRIPTION
## Problem

The MCP server always reported `dotnet-mcp 1.0.0` in the `initialize` response regardless of the actual NuGet package version, because the version was hardcoded in `Program.cs`:

\\\
Server (dotnet-mcp 1.0.0) method 'initialize' request handler called.
\\\

## Fix

Read `AssemblyInformationalVersionAttribute` (set by MinVer from git tags) at runtime. The server now correctly reports the actual version:

\\\
Server (dotnet-mcp 1.1.1+1324b2da...) method 'initialize' request handler called.
\\\

Falls back to `AssemblyName.Version` then `0.0.0` if the attribute is unavailable.

## Testing

All 58 conformance + capabilities tests pass.