### PR TITLE
chore: update .NET package dependencies

### DIFF
--- a/DotNetMcp.Tests/DotNetMcp.Tests.csproj
+++ b/DotNetMcp.Tests/DotNetMcp.Tests.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>

--- a/DotNetMcp/DotNetMcp.csproj
+++ b/DotNetMcp/DotNetMcp.csproj
@@ -46,11 +46,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="18.4.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="10.0.203" />
-    <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="10.0.203" />
+    <PackageReference Include="Microsoft.Build" Version="18.6.3" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="10.0.300" />
+    <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="10.0.300" />
     <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
     <PackageReference Include="MinVer" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- update Microsoft.Build and Microsoft.Build.Utilities.Core in DotNetMcp to 18.6.3
- update Microsoft.Extensions.Hosting in DotNetMcp to 10.0.8
- update Microsoft.TemplateEngine.Abstractions and Microsoft.TemplateEngine.Edge in DotNetMcp to 10.0.300
- update Microsoft.Extensions.Logging.Abstractions in tests to 10.0.8
- update Microsoft.Extensions.TimeProvider.Testing in tests to 10.6.0
- update Microsoft.Testing.Extensions.CodeCoverage in tests to 18.7.0

## Validation
- `dotnet build D:\Users\Jon\Documents\GitHub\dotnet-mcp\DotNetMcp.slnx` succeeded