### PR TITLE
feat: add opt-in MCP governance integration

### DIFF
--- a/DotNetMcp.Tests/Server/McpGovernanceConfigurationTests.cs
+++ b/DotNetMcp.Tests/Server/McpGovernanceConfigurationTests.cs
@@ -1,0 +1,48 @@
+using DotNetMcp;
+using Microsoft.Extensions.Configuration;
+
+namespace DotNetMcp.Tests.Server;
+
+public class McpGovernanceConfigurationTests
+{
+    [Fact]
+    public void Load_UsesSafeDefaults_WhenSectionMissing()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var result = McpGovernanceConfiguration.Load(configuration);
+
+        Assert.False(result.Enabled);
+        Assert.Equal("did:mcp:anonymous", result.DefaultAgentId);
+        Assert.Equal("dotnet-mcp", result.ServerName);
+        Assert.Empty(result.PolicyPaths);
+    }
+
+    [Fact]
+    public void Load_NormalizesPolicyPaths_WhenConfigured()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["McpGovernance:Enabled"] = "true",
+            ["McpGovernance:DefaultAgentId"] = "did:mcp:server",
+            ["McpGovernance:ServerName"] = "contoso-support",
+            ["McpGovernance:PolicyPaths:0"] = " policies/mcp.yaml ",
+            ["McpGovernance:PolicyPaths:1"] = "",
+            ["McpGovernance:PolicyPaths:2"] = "policies/mcp.yaml",
+            ["McpGovernance:PolicyPaths:3"] = "policies/extra.yaml",
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        var result = McpGovernanceConfiguration.Load(configuration);
+
+        Assert.True(result.Enabled);
+        Assert.Equal("did:mcp:server", result.DefaultAgentId);
+        Assert.Equal("contoso-support", result.ServerName);
+        Assert.Equal(2, result.PolicyPaths.Count);
+        Assert.Equal("policies/mcp.yaml", result.PolicyPaths[0]);
+        Assert.Equal("policies/extra.yaml", result.PolicyPaths[1]);
+    }
+}

--- a/DotNetMcp/DotNetMcp.csproj
+++ b/DotNetMcp/DotNetMcp.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AgentGovernance.Extensions.ModelContextProtocol" Version="4.0.0" />
     <PackageReference Include="Microsoft.Build" Version="18.6.3" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />

--- a/DotNetMcp/McpGovernanceConfiguration.cs
+++ b/DotNetMcp/McpGovernanceConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Configuration;
+
+namespace DotNetMcp;
+
+/// <summary>
+/// Provides opt-in settings for MCP governance integration.
+/// </summary>
+public sealed class McpGovernanceConfiguration
+{
+    public const string SectionName = "McpGovernance";
+
+    public bool Enabled { get; init; }
+
+    public string DefaultAgentId { get; init; } = "did:mcp:anonymous";
+
+    public string ServerName { get; init; } = "dotnet-mcp";
+
+    public IReadOnlyList<string> PolicyPaths { get; init; } = [];
+
+    public static McpGovernanceConfiguration Load(IConfiguration configuration)
+    {
+        var section = configuration.GetSection(SectionName);
+        var enabled = section.GetValue<bool>("Enabled");
+
+        var configuredPaths = section
+            .GetSection("PolicyPaths")
+            .Get<string[]>()?
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var policyPaths = configuredPaths is { Length: > 0 }
+            ? configuredPaths
+            : [];
+
+        var defaultAgentId = section.GetValue<string>("DefaultAgentId");
+        var serverName = section.GetValue<string>("ServerName");
+
+        return new McpGovernanceConfiguration
+        {
+            Enabled = enabled,
+            DefaultAgentId = string.IsNullOrWhiteSpace(defaultAgentId) ? "did:mcp:anonymous" : defaultAgentId,
+            ServerName = string.IsNullOrWhiteSpace(serverName) ? "dotnet-mcp" : serverName,
+            PolicyPaths = policyPaths,
+        };
+    }
+}

--- a/DotNetMcp/Program.cs
+++ b/DotNetMcp/Program.cs
@@ -1,4 +1,5 @@
 using DotNetMcp;
+using AgentGovernance.Extensions.ModelContextProtocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -9,6 +10,7 @@ using ModelContextProtocol.Server;
 using System.Diagnostics;
 
 var builder = Host.CreateApplicationBuilder(args);
+var governanceConfiguration = McpGovernanceConfiguration.Load(builder.Configuration);
 
 builder.Logging.AddConsole(options =>
 {
@@ -70,7 +72,23 @@ mcpServerBuilder
     .WithTools<DotNetCliTools>()
     .WithResources<DotNetResources>()
     .WithResources<McpAppsResources>()
-    .WithPrompts<DotNetPrompts>()
+    .WithPrompts<DotNetPrompts>();
+
+if (governanceConfiguration.Enabled)
+{
+    mcpServerBuilder.WithGovernance(options =>
+    {
+        options.DefaultAgentId = governanceConfiguration.DefaultAgentId;
+        options.ServerName = governanceConfiguration.ServerName;
+
+        foreach (var policyPath in governanceConfiguration.PolicyPaths)
+        {
+            options.PolicyPaths.Add(policyPath);
+        }
+    });
+}
+
+mcpServerBuilder
     .WithSubscribeToResourcesHandler((context, ct) =>
     {
         var uri = context.Params?.Uri;

--- a/README.md
+++ b/README.md
@@ -177,6 +177,25 @@ The MCP server uses official .NET SDK APIs and CLI commands, ensuring:
   - Opt-out available with `unsafeOutput=true` for advanced debugging
   - Patterns include: database credentials, cloud provider keys, tokens, certificates, and more
   - Performance impact is minimal and tested to complete within 500ms for 10,000 lines
+- **Optional MCP governance controls** (preview)
+  - Uses `Microsoft.AgentGovernance.Extensions.ModelContextProtocol` when enabled via configuration
+  - Disabled by default to preserve existing behavior and compatibility
+  - Does not ship with a default enforced policy; provide your own policy file(s) when needed
+  - See `doc/mcp-governance.md` for a sample `mcp.yaml` policy template
+  - Sources:
+    - Agent Governance Toolkit repository: https://github.com/microsoft/agent-governance-toolkit
+    - Agent Governance Toolkit for .NET: https://github.com/microsoft/agent-governance-toolkit/tree/main/agent-governance-dotnet
+    - Announcement: https://devblogs.microsoft.com/dotnet/announcing-agent-governance-toolkit-mcp-extensions-for-dotnet/
+  - Startup scanning, policy-based tool authorization, and response sanitization can be enabled with:
+
+```json
+"McpGovernance": {
+  "Enabled": true,
+  "DefaultAgentId": "did:mcp:anonymous",
+  "ServerName": "dotnet-mcp",
+  "PolicyPaths": ["/path/to/your/policies/mcp.yaml"]
+}
+```
 
 ## How It Works
 

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -27,5 +27,11 @@
         "Endpoint": "http://localhost:4317"
       }
     }
+  },
+  "McpGovernance": {
+    "Enabled": false,
+    "DefaultAgentId": "did:mcp:anonymous",
+    "ServerName": "dotnet-mcp",
+    "PolicyPaths": []
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -27,5 +27,11 @@
         "Endpoint": "http://localhost:4317"
       }
     }
+  },
+  "McpGovernance": {
+    "Enabled": false,
+    "DefaultAgentId": "did:mcp:anonymous",
+    "ServerName": "dotnet-mcp",
+    "PolicyPaths": []
   }
 }

--- a/doc/mcp-governance.md
+++ b/doc/mcp-governance.md
@@ -1,0 +1,44 @@
+# MCP Governance Configuration
+
+`dotnet-mcp` supports opt-in governance via `Microsoft.AgentGovernance.Extensions.ModelContextProtocol`.
+
+Governance is disabled by default. When enabled, you can provide one or more policy files through `McpGovernance:PolicyPaths`.
+
+## Example appsettings configuration
+
+```json
+"McpGovernance": {
+  "Enabled": true,
+  "DefaultAgentId": "did:mcp:anonymous",
+  "ServerName": "dotnet-mcp",
+  "PolicyPaths": [
+    "/path/to/your/policies/mcp.yaml"
+  ]
+}
+```
+
+## Example policy file (`mcp.yaml`)
+
+```yaml
+apiVersion: governance.toolkit/v1
+version: "1.0"
+name: dotnet-mcp-sample-policy
+default_action: deny
+rules:
+  - name: allow-dotnet-tools
+    condition: "tool_name =~ '^dotnet_'"
+    action: allow
+    priority: 100
+```
+
+## Notes
+
+- This repository intentionally does not bundle a default policy file for runtime enforcement.
+- The sample above is a starting point; tune actions and conditions to your environment and threat model.
+- If no policy paths are provided, governance behavior depends on the toolkit defaults and your runtime options.
+
+## References
+
+- Agent Governance Toolkit repository: https://github.com/microsoft/agent-governance-toolkit
+- Agent Governance Toolkit for .NET: https://github.com/microsoft/agent-governance-toolkit/tree/main/agent-governance-dotnet
+- Announcement: https://devblogs.microsoft.com/dotnet/announcing-agent-governance-toolkit-mcp-extensions-for-dotnet/


### PR DESCRIPTION
Adds opt-in MCP governance integration using Microsoft.AgentGovernance.Extensions.ModelContextProtocol, introduces McpGovernance configuration loading, documents governance setup and official references, and adds lightweight governance configuration tests.