### PR TITLE
ci: speed up PR runs with fast-path and targeted test execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
         description: "Run MCP scenario (integration) tests"
         required: false
         default: "true"
+      runFullValidation:
+        description: "Run full tests with coverage and performance smoke"
+        required: false
+        default: "true"
 
 # Cancel in-progress runs for the same branch to save CI resources
 concurrency:
@@ -31,45 +35,79 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Detect changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - '**/*.md'
+              - 'doc/**'
+              - '.github/ISSUE_TEMPLATE/**'
+              - '.github/pull_request_template.md'
+            non_docs:
+              - 'DotNetMcp/**'
+              - 'DotNetMcp.Tests/**'
+              - 'scripts/**'
+              - '.github/workflows/**'
+              - '*.slnx'
+              - '*.json'
+              - '*.props'
+              - '*.targets'
+              - '*.csproj'
+            scenario_related:
+              - 'DotNetMcp.Tests/Scenarios/**'
+              - 'DotNetMcp/Prompts/**'
+              - 'DotNetMcp/Resources/**'
+
       - name: Setup .NET
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: setup_dotnet
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
       - name: Display .NET info
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: dotnet_info
         run: dotnet --info
 
       - name: Restore dependencies
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: restore
         run: dotnet restore DotNetMcp.slnx
 
       - name: Build
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: build
         run: dotnet build DotNetMcp.slnx --no-restore --configuration Release
 
       - name: Validate server.json
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: validate_server_json
         run: pwsh -File scripts/validate-server-json.ps1
 
       - name: Run MCP Conformance Tests
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: conformance_tests
         run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-class "*McpConformanceTests"
 
       - name: Run MCP Scenario Tests
         id: scenario_tests
-        # Run on all CI builds by default. Allow manual workflow runs to skip if desired.
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.runScenarioTests == 'true' }}
+        # For PRs, run scenario tests only when scenario-related/core files changed.
+        # For push/manual runs, preserve existing behavior.
+        if: ${{ (github.event_name == 'pull_request' && steps.changes.outputs.non_docs == 'true' && steps.changes.outputs.scenario_related == 'true') || (github.event_name == 'workflow_dispatch' && inputs.runScenarioTests == 'true') || github.event_name == 'push' }}
         env:
           DOTNET_MCP_SCENARIO_TESTS: "1"
         run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-namespace "*DotNetMcp.Tests.Scenarios*"
 
       - name: Test
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         id: test
         run: dotnet test --solution DotNetMcp.slnx --no-build --configuration Release --verbosity normal -- --coverage --coverage-output-format cobertura
 
       - name: Collect coverage artifact
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         id: collect_coverage
         shell: bash
         run: |
@@ -85,7 +123,7 @@ jobs:
       - name: Upload coverage to Codecov
         id: upload_codecov
         # Only upload from pushes (PR workflows from forks don't have secrets).
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true')) && github.ref == 'refs/heads/main' }}
         uses: codecov/codecov-action@v6
         with:
           files: coverage.cobertura.xml
@@ -93,6 +131,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage artifact
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         id: upload_coverage_artifact
         uses: actions/upload-artifact@v7
         with:
@@ -103,6 +142,7 @@ jobs:
         id: performance_smoke
         # Performance tests are informational only and should not block CI
         # Results are uploaded as artifacts for review
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         continue-on-error: true
         shell: bash
         run: |
@@ -116,6 +156,7 @@ jobs:
           cat performance-results.txt
 
       - name: Upload performance results artifact
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         id: upload_performance_artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,15 +50,11 @@ jobs:
               - '.github/ISSUE_TEMPLATE/**'
               - '.github/pull_request_template.md'
             non_docs:
-              - 'DotNetMcp/**'
-              - 'DotNetMcp.Tests/**'
-              - 'scripts/**'
-              - '.github/workflows/**'
-              - '*.slnx'
-              - '*.json'
-              - '*.props'
-              - '*.targets'
-              - '*.csproj'
+              - '**'
+              - '!**/*.md'
+              - '!doc/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/pull_request_template.md'
             scenario_related:
               - 'DotNetMcp.Tests/Scenarios/**'
               - 'DotNetMcp/Prompts/**'
@@ -97,6 +93,7 @@ jobs:
         run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-class "*McpConformanceTests"
 
   pr_scenario:
+    # Runs only when scenario-specific files (Scenarios/Prompts/Resources) change in a non-docs PR.
     needs: detect_changes
     if: ${{ github.event_name == 'pull_request' && needs.detect_changes.outputs.non_docs == 'true' && needs.detect_changes.outputs.scenario_related == 'true' }}
     runs-on: ubuntu-latest
@@ -233,7 +230,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         id: upload_codecov
-        # Only upload from pushes to main (workflow_dispatch runs on the selected ref).
+        # Upload from any full_validation run (push or workflow_dispatch) targeting the main branch.
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  detect_changes:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    outputs:
+      non_docs: ${{ steps.changes.outputs.non_docs }}
+      scenario_related: ${{ steps.changes.outputs.scenario_related }}
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
@@ -60,54 +64,161 @@ jobs:
               - 'DotNetMcp/Prompts/**'
               - 'DotNetMcp/Resources/**'
 
+  pr_conformance:
+    needs: detect_changes
+    if: ${{ github.event_name == 'pull_request' && needs.detect_changes.outputs.non_docs == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+
       - name: Setup .NET
-        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore DotNetMcp.slnx
+
+      - name: Build
+        run: dotnet build DotNetMcp.slnx --no-restore --configuration Release
+
+      - name: Validate server.json
+        run: pwsh -File scripts/validate-server-json.ps1
+
+      - name: Run MCP Conformance Tests
+        run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-class "*McpConformanceTests"
+
+  pr_scenario:
+    needs: detect_changes
+    if: ${{ github.event_name == 'pull_request' && needs.detect_changes.outputs.non_docs == 'true' && needs.detect_changes.outputs.scenario_related == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore DotNetMcp.slnx
+
+      - name: Build
+        run: dotnet build DotNetMcp.slnx --no-restore --configuration Release
+
+      - name: Run MCP Scenario Tests
+        env:
+          DOTNET_MCP_SCENARIO_TESTS: "1"
+        run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-namespace "*DotNetMcp.Tests.Scenarios*"
+
+  manual_quick_checks:
+    needs: detect_changes
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.runFullValidation != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore DotNetMcp.slnx
+
+      - name: Build
+        run: dotnet build DotNetMcp.slnx --no-restore --configuration Release
+
+      - name: Validate server.json
+        run: pwsh -File scripts/validate-server-json.ps1
+
+      - name: Run MCP Conformance Tests
+        run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-class "*McpConformanceTests"
+
+      - name: Run MCP Scenario Tests
+        if: ${{ inputs.runScenarioTests == 'true' }}
+        env:
+          DOTNET_MCP_SCENARIO_TESTS: "1"
+        run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-namespace "*DotNetMcp.Tests.Scenarios*"
+
+  full_validation:
+    needs: detect_changes
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
         id: setup_dotnet
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
       - name: Display .NET info
-        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: dotnet_info
         run: dotnet --info
 
       - name: Restore dependencies
-        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: restore
         run: dotnet restore DotNetMcp.slnx
 
       - name: Build
-        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: build
         run: dotnet build DotNetMcp.slnx --no-restore --configuration Release
 
       - name: Validate server.json
-        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: validate_server_json
         run: pwsh -File scripts/validate-server-json.ps1
 
       - name: Run MCP Conformance Tests
-        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.non_docs == 'true' }}
         id: conformance_tests
         run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-class "*McpConformanceTests"
 
       - name: Run MCP Scenario Tests
         id: scenario_tests
-        # For PRs, run scenario tests only when scenario-related/core files changed.
-        # For push/manual runs, preserve existing behavior.
-        if: ${{ (github.event_name == 'pull_request' && steps.changes.outputs.non_docs == 'true' && steps.changes.outputs.scenario_related == 'true') || (github.event_name == 'workflow_dispatch' && inputs.runScenarioTests == 'true') || github.event_name == 'push' }}
+        # For push runs, always run. For manual full runs, allow skipping with input.
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runScenarioTests == 'true') }}
         env:
           DOTNET_MCP_SCENARIO_TESTS: "1"
         run: dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj --no-build --configuration Release --verbosity normal -- --filter-namespace "*DotNetMcp.Tests.Scenarios*"
 
       - name: Test
-        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         id: test
         run: dotnet test --solution DotNetMcp.slnx --no-build --configuration Release --verbosity normal -- --coverage --coverage-output-format cobertura
 
       - name: Collect coverage artifact
-        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         id: collect_coverage
         shell: bash
         run: |
@@ -122,8 +233,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         id: upload_codecov
-        # Only upload from pushes (PR workflows from forks don't have secrets).
-        if: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true')) && github.ref == 'refs/heads/main' }}
+        # Only upload from pushes to main (workflow_dispatch runs on the selected ref).
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: codecov/codecov-action@v6
         with:
           files: coverage.cobertura.xml
@@ -131,7 +242,6 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage artifact
-        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         id: upload_coverage_artifact
         uses: actions/upload-artifact@v7
         with:
@@ -142,7 +252,6 @@ jobs:
         id: performance_smoke
         # Performance tests are informational only and should not block CI
         # Results are uploaded as artifacts for review
-        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         continue-on-error: true
         shell: bash
         run: |
@@ -156,7 +265,6 @@ jobs:
           cat performance-results.txt
 
       - name: Upload performance results artifact
-        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.runFullValidation == 'true') }}
         id: upload_performance_artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## What this changes
Reduces standard pull request CI time by introducing a PR fast-path and path-based test gating in [build.yml](.github/workflows/build.yml).

## Key optimizations
- Adds path detection with dorny/paths-filter.
- Skips .NET setup/build/tests for docs-only PRs.
- Keeps conformance tests on non-doc PRs.
- Runs scenario tests on PRs only when scenario-related paths changed.
- Moves full test + coverage and performance smoke to:
  - pushes to main, or
  - manual runs with unFullValidation=true.

## Why this should be faster
Previously PRs ran:
- conformance tests
- scenario tests
- full solution tests with coverage
- performance smoke tests

Now standard PRs run a much smaller set, while full validation still happens on main and can be manually requested.

## Safety model
- Full validation is still preserved for main.
- Manual workflow dispatch can run full validation on demand.
- Conformance checks remain for regular code PRs.

