### PR TITLE
feat: add dotnet://workspace MCP resource snapshot

### DIFF
--- a/DotNetMcp.Tests/Resources/ResourceSubscriptionManagerTests.cs
+++ b/DotNetMcp.Tests/Resources/ResourceSubscriptionManagerTests.cs
@@ -111,6 +111,7 @@ public class ResourceSubscriptionManagerTests
         Assert.Contains("dotnet://runtime-info", ResourceSubscriptionManager.KnownResourceUris);
         Assert.Contains("dotnet://templates", ResourceSubscriptionManager.KnownResourceUris);
         Assert.Contains("dotnet://frameworks", ResourceSubscriptionManager.KnownResourceUris);
+        Assert.Contains("dotnet://workspace", ResourceSubscriptionManager.KnownResourceUris);
         Assert.Contains("dotnet://telemetry-data", ResourceSubscriptionManager.KnownResourceUris);
     }
 

--- a/DotNetMcp.Tests/Resources/WorkspaceSnapshotResourceTests.cs
+++ b/DotNetMcp.Tests/Resources/WorkspaceSnapshotResourceTests.cs
@@ -146,6 +146,44 @@ EndGlobal
         }
     }
 
+    [Fact]
+    public void BuildWorkspaceSnapshot_WithAbsoluteSolutionProjectPath_IncludesProject()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var projectPath = Path.Join(tempDir, "src", "AbsolutePathProject", "AbsolutePathProject.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+            File.WriteAllText(projectPath, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+""");
+
+            var solutionPath = Path.Join(tempDir, "AbsolutePathProject.sln");
+            var slnProjectPath = projectPath.Replace('\\', '/');
+            File.WriteAllText(solutionPath, $$"""
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AbsolutePathProject", "{{slnProjectPath}}", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Global
+EndGlobal
+""");
+
+            var snapshot = DotNetResources.BuildWorkspaceSnapshot(tempDir);
+
+            Assert.Single(snapshot.Projects);
+            Assert.Equal("src/AbsolutePathProject/AbsolutePathProject.csproj", snapshot.Projects[0].Path);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
     private static string CreateTempDirectory()
     {
         var tempDir = Path.Join(Path.GetTempPath(), "dotnet-mcp-tests", Guid.NewGuid().ToString("N"));

--- a/DotNetMcp.Tests/Resources/WorkspaceSnapshotResourceTests.cs
+++ b/DotNetMcp.Tests/Resources/WorkspaceSnapshotResourceTests.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using DotNetMcp;
+using Xunit;
+
+namespace DotNetMcp.Tests;
+
+public class WorkspaceSnapshotResourceTests
+{
+    [Fact]
+    public void BuildWorkspaceSnapshot_UsesSolutionAndExtractsProjectMetadata()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var appProject = Path.Join(tempDir, "src", "MyApp", "MyApp.csproj");
+            var testProject = Path.Join(tempDir, "tests", "MyApp.Tests", "MyApp.Tests.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(appProject)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(testProject)!);
+
+            File.WriteAllText(appProject, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="3.0.0" />
+    <PackageReference Include="Polly" Version="8.0.0" />
+  </ItemGroup>
+</Project>
+""");
+
+            File.WriteAllText(testProject, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.8.0" />
+  </ItemGroup>
+</Project>
+""");
+
+            var solutionPath = Path.Join(tempDir, "MyApp.sln");
+            File.WriteAllText(solutionPath, """
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyApp", "src/MyApp/MyApp.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyApp.Tests", "tests/MyApp.Tests/MyApp.Tests.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+EndGlobal
+""");
+
+            var snapshot = DotNetResources.BuildWorkspaceSnapshot(tempDir);
+
+            Assert.Equal("MyApp.sln", snapshot.Solution);
+            Assert.Equal(2, snapshot.Projects.Count);
+
+            var app = snapshot.Projects.Single(p => p.Name == "MyApp");
+            Assert.Equal("src/MyApp/MyApp.csproj", app.Path);
+            Assert.Contains("net10.0", app.TargetFrameworks);
+            Assert.Equal(2, app.PackageCount);
+            Assert.False(app.IsTestProject);
+
+            var tests = snapshot.Projects.Single(p => p.Name == "MyApp.Tests");
+            Assert.Equal("tests/MyApp.Tests/MyApp.Tests.csproj", tests.Path);
+            Assert.Contains("net10.0", tests.TargetFrameworks);
+            Assert.Contains("net9.0", tests.TargetFrameworks);
+            Assert.Equal(1, tests.PackageCount);
+            Assert.True(tests.IsTestProject);
+
+            Assert.True(DateTimeOffset.TryParse(snapshot.GeneratedAt, out _));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void BuildWorkspaceSnapshot_WithoutSolution_FallsBackToRecursiveProjectDiscovery()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var projectPath = Path.Join(tempDir, "src", "OnlyProject", "OnlyProject.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+            File.WriteAllText(projectPath, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+""");
+
+            var ignoredObjProject = Path.Join(tempDir, "obj", "Generated", "Generated.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(ignoredObjProject)!);
+            File.WriteAllText(ignoredObjProject, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+            var snapshot = DotNetResources.BuildWorkspaceSnapshot(tempDir);
+
+            Assert.Null(snapshot.Solution);
+            Assert.Single(snapshot.Projects);
+            Assert.Equal("OnlyProject", snapshot.Projects[0].Name);
+            Assert.Equal("src/OnlyProject/OnlyProject.csproj", snapshot.Projects[0].Path);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task GetWorkspaceSnapshot_ReturnsCachedEnvelopeWithWorkspaceData()
+    {
+        var tempDir = CreateTempDirectory();
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+
+        try
+        {
+            var projectPath = Path.Join(tempDir, "App", "App.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+            File.WriteAllText(projectPath, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+""");
+
+            Directory.SetCurrentDirectory(tempDir);
+            var resources = new DotNetResources(Microsoft.Extensions.Logging.Abstractions.NullLogger<DotNetResources>.Instance);
+            var json = await resources.GetWorkspaceSnapshot();
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.True(doc.RootElement.TryGetProperty("data", out var data));
+            Assert.True(data.TryGetProperty("projects", out var projects));
+            Assert.True(projects.GetArrayLength() >= 1);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "dotnet-mcp-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+}

--- a/DotNetMcp/Resources/DotNetResources.cs
+++ b/DotNetMcp/Resources/DotNetResources.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
@@ -15,6 +17,24 @@ internal record SdkInfo(string Version, string Path);
 internal record RuntimeInfo(string Name, string Version, string Path);
 
 /// <summary>
+/// Represents a project in the workspace snapshot.
+/// </summary>
+internal record WorkspaceProjectInfo(
+    string Name,
+    string Path,
+    IReadOnlyList<string> TargetFrameworks,
+    int PackageCount,
+    bool IsTestProject);
+
+/// <summary>
+/// Represents a workspace snapshot for the dotnet://workspace resource.
+/// </summary>
+internal record WorkspaceSnapshot(
+    string? Solution,
+    IReadOnlyList<WorkspaceProjectInfo> Projects,
+    string GeneratedAt);
+
+/// <summary>
 /// MCP Resources for .NET environment information.
 /// Provides read-only access to .NET SDK, runtime, template, and framework metadata.
 /// Implements caching with configurable TTL and metrics for performance.
@@ -29,6 +49,11 @@ public sealed class DotNetResources
         new("SDK", defaultTtlSeconds: 300);
     private static readonly CachedResourceManager<List<RuntimeInfo>> _runtimeCacheManager =
         new("Runtime", defaultTtlSeconds: 300);
+    private static readonly CachedResourceManager<WorkspaceSnapshot> _workspaceCacheManager =
+        new("Workspace", defaultTtlSeconds: 60);
+
+    private static readonly Regex SlnProjectPathRegex =
+        new("\"(?<path>[^\"\\r\\n]+\\.csproj)\"", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     internal static List<SdkInfo> ParseSdkListOutput(string sdkListOutput)
     {
@@ -139,10 +164,12 @@ public sealed class DotNetResources
     {
         await _sdkCacheManager.ClearAsync();
         await _runtimeCacheManager.ClearAsync();
+        await _workspaceCacheManager.ClearAsync();
         await TemplateEngineHelper.ClearCacheAsync();
 
         _sdkCacheManager.ResetMetrics();
         _runtimeCacheManager.ResetMetrics();
+        _workspaceCacheManager.ResetMetrics();
     }
 
     /// <summary>
@@ -154,6 +181,11 @@ public sealed class DotNetResources
     /// Gets Runtime cache metrics.
     /// </summary>
     public static CacheMetrics GetRuntimeMetrics() => _runtimeCacheManager.Metrics;
+
+    /// <summary>
+    /// Gets workspace cache metrics.
+    /// </summary>
+    public static CacheMetrics GetWorkspaceMetrics() => _workspaceCacheManager.Metrics;
 
     [McpServerResource(
         UriTemplate = "dotnet://sdk-info",
@@ -323,6 +355,204 @@ public sealed class DotNetResources
             return JsonSerializer.Serialize(new { error = ex.Message });
         }
     }
+
+    [McpServerResource(
+        UriTemplate = "dotnet://workspace",
+        Name = "Workspace Snapshot",
+        Title = "Compact workspace-level snapshot of solution and projects",
+        MimeType = "application/json")]
+    [McpMeta("category", "workspace")]
+    [McpMeta("dataFormat", "json")]
+    [McpMeta("refreshable", true)]
+    [McpMeta("cached", true)]
+    public async Task<string> GetWorkspaceSnapshot()
+    {
+        _logger.LogDebug("Reading workspace snapshot");
+        try
+        {
+            var entry = await _workspaceCacheManager.GetOrLoadAsync(async () =>
+            {
+                var snapshot = BuildWorkspaceSnapshot(Directory.GetCurrentDirectory());
+                return await Task.FromResult(snapshot);
+            });
+
+            return _workspaceCacheManager.GetJsonResponse(entry, entry.Data, DateTime.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting workspace snapshot");
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+    }
+
+    internal static WorkspaceSnapshot BuildWorkspaceSnapshot(string workspaceRoot)
+    {
+        var root = string.IsNullOrWhiteSpace(workspaceRoot)
+            ? Directory.GetCurrentDirectory()
+            : workspaceRoot;
+
+        var solutionPath = FindPrimarySolution(root);
+        var projectPaths = solutionPath != null
+            ? GetProjectsFromSolution(solutionPath)
+            : DiscoverProjectsRecursively(root);
+
+        if (projectPaths.Count == 0)
+        {
+            // Fallback: if solution parsing produced no projects, do recursive discovery.
+            projectPaths = DiscoverProjectsRecursively(root);
+        }
+
+        var projects = projectPaths
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(File.Exists)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .Select(path => BuildWorkspaceProjectInfo(root, path))
+            .ToArray();
+
+        var solutionRelative = solutionPath == null
+            ? null
+            : ToRepoRelativePath(root, solutionPath);
+
+        return new WorkspaceSnapshot(
+            solutionRelative,
+            projects,
+            DateTime.UtcNow.ToString("O"));
+    }
+
+    private static WorkspaceProjectInfo BuildWorkspaceProjectInfo(string root, string projectPath)
+    {
+        var targetFrameworks = GetTargetFrameworks(projectPath);
+        var packageCount = GetPackageReferenceCount(projectPath);
+        var projectName = Path.GetFileNameWithoutExtension(projectPath);
+
+        var isTestProject = projectName.EndsWith(".Tests", StringComparison.OrdinalIgnoreCase)
+            || IsTestProjectFlagEnabled(projectPath);
+
+        return new WorkspaceProjectInfo(
+            projectName,
+            ToRepoRelativePath(root, projectPath),
+            targetFrameworks,
+            packageCount,
+            isTestProject);
+    }
+
+    private static string? FindPrimarySolution(string root)
+    {
+        var slnx = Directory.GetFiles(root, "*.slnx", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+
+        if (!string.IsNullOrWhiteSpace(slnx))
+            return slnx;
+
+        return Directory.GetFiles(root, "*.sln", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
+    private static List<string> GetProjectsFromSolution(string solutionPath)
+    {
+        var projectPaths = new List<string>();
+        var solutionDir = Path.GetDirectoryName(solutionPath) ?? Directory.GetCurrentDirectory();
+
+        string solutionContent;
+        try
+        {
+            solutionContent = File.ReadAllText(solutionPath);
+        }
+        catch
+        {
+            return projectPaths;
+        }
+
+        var matches = SlnProjectPathRegex.Matches(solutionContent);
+        foreach (Match match in matches)
+        {
+            var relativePath = match.Groups["path"].Value;
+            if (string.IsNullOrWhiteSpace(relativePath))
+                continue;
+
+            var normalizedRelativePath = relativePath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+            var absolutePath = Path.GetFullPath(Path.Join(solutionDir, normalizedRelativePath));
+
+            if (absolutePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                projectPaths.Add(absolutePath);
+            }
+        }
+
+        return projectPaths;
+    }
+
+    private static List<string> DiscoverProjectsRecursively(string root)
+    {
+        return Directory
+            .GetFiles(root, "*.csproj", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+                && !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private static IReadOnlyList<string> GetTargetFrameworks(string projectPath)
+    {
+        try
+        {
+            var document = XDocument.Load(projectPath);
+            var frameworks = new List<string>();
+
+            frameworks.AddRange(document.Descendants()
+                .Where(e => e.Name.LocalName == "TargetFramework")
+                .Select(e => e.Value?.Trim())
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .OfType<string>());
+
+            frameworks.AddRange(document.Descendants()
+                .Where(e => e.Name.LocalName == "TargetFrameworks")
+                .SelectMany(e => (e.Value ?? string.Empty)
+                    .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)));
+
+            return frameworks
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static int GetPackageReferenceCount(string projectPath)
+    {
+        try
+        {
+            var document = XDocument.Load(projectPath);
+            return document.Descendants()
+                .Count(e => e.Name.LocalName == "PackageReference" && e.Attribute("Include") != null);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static bool IsTestProjectFlagEnabled(string projectPath)
+    {
+        try
+        {
+            var document = XDocument.Load(projectPath);
+            return document.Descendants()
+                .Any(e => e.Name.LocalName == "IsTestProject"
+                    && string.Equals(e.Value?.Trim(), "true", StringComparison.OrdinalIgnoreCase));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string ToRepoRelativePath(string root, string absolutePath)
+        => Path.GetRelativePath(root, absolutePath).Replace('\\', '/');
 
     /// <summary>
     /// Example resource demonstrating CAPABILITY_NOT_AVAILABLE usage when a resource is conditionally disabled.

--- a/DotNetMcp/Resources/DotNetResources.cs
+++ b/DotNetMcp/Resources/DotNetResources.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -376,14 +377,48 @@ public sealed class DotNetResources
                 return await Task.FromResult(snapshot);
             });
 
-            return _workspaceCacheManager.GetJsonResponse(entry, entry.Data, DateTime.UtcNow);
+            return _workspaceCacheManager.GetJsonResponse(entry, ToWorkspaceSnapshotResourceData(entry.Data), DateTime.UtcNow);
         }
-        catch (Exception ex)
+        catch (IOException ex)
+        {
+            _logger.LogError(ex, "Error getting workspace snapshot");
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogError(ex, "Error getting workspace snapshot");
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogError(ex, "Error getting workspace snapshot");
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogError(ex, "Error getting workspace snapshot");
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+        catch (XmlException ex)
         {
             _logger.LogError(ex, "Error getting workspace snapshot");
             return JsonSerializer.Serialize(new { error = ex.Message });
         }
     }
+
+    private static object ToWorkspaceSnapshotResourceData(WorkspaceSnapshot snapshot) => new
+    {
+        solution = snapshot.Solution,
+        projects = snapshot.Projects.Select(project => new
+        {
+            name = project.Name,
+            path = project.Path,
+            targetFrameworks = project.TargetFrameworks,
+            packageCount = project.PackageCount,
+            isTestProject = project.IsTestProject
+        }),
+        generatedAt = snapshot.GeneratedAt
+    };
 
     internal static WorkspaceSnapshot BuildWorkspaceSnapshot(string workspaceRoot)
     {
@@ -460,28 +495,52 @@ public sealed class DotNetResources
         {
             solutionContent = File.ReadAllText(solutionPath);
         }
-        catch
+        catch (IOException)
+        {
+            return projectPaths;
+        }
+        catch (UnauthorizedAccessException)
         {
             return projectPaths;
         }
 
-        var matches = SlnProjectPathRegex.Matches(solutionContent);
-        foreach (Match match in matches)
-        {
-            var relativePath = match.Groups["path"].Value;
-            if (string.IsNullOrWhiteSpace(relativePath))
-                continue;
-
-            var normalizedRelativePath = relativePath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
-            var absolutePath = Path.GetFullPath(Path.Join(solutionDir, normalizedRelativePath));
-
-            if (absolutePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
-            {
-                projectPaths.Add(absolutePath);
-            }
-        }
+        projectPaths.AddRange(
+            SlnProjectPathRegex
+                .Matches(solutionContent)
+                .Select(match => match.Groups["path"].Value)
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Select(path => path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar))
+                .Select(path => TryGetFullProjectPath(solutionDir, path, out var fullPath) ? fullPath : null)
+                .Where(path => path != null && path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+                .Cast<string>());
 
         return projectPaths;
+    }
+
+    private static bool TryGetFullProjectPath(string solutionDir, string projectPath, out string fullPath)
+    {
+        fullPath = string.Empty;
+        try
+        {
+            var candidatePath = Path.IsPathRooted(projectPath)
+                ? projectPath
+                : Path.Join(solutionDir, projectPath);
+
+            fullPath = Path.GetFullPath(candidatePath);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+        catch (PathTooLongException)
+        {
+            return false;
+        }
     }
 
     private static List<string> DiscoverProjectsRecursively(string root)
@@ -516,7 +575,19 @@ public sealed class DotNetResources
                 .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
         }
-        catch
+        catch (IOException)
+        {
+            return [];
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return [];
+        }
+        catch (XmlException)
+        {
+            return [];
+        }
+        catch (InvalidOperationException)
         {
             return [];
         }
@@ -530,7 +601,19 @@ public sealed class DotNetResources
             return document.Descendants()
                 .Count(e => e.Name.LocalName == "PackageReference" && e.Attribute("Include") != null);
         }
-        catch
+        catch (IOException)
+        {
+            return 0;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return 0;
+        }
+        catch (XmlException)
+        {
+            return 0;
+        }
+        catch (InvalidOperationException)
         {
             return 0;
         }
@@ -545,7 +628,19 @@ public sealed class DotNetResources
                 .Any(e => e.Name.LocalName == "IsTestProject"
                     && string.Equals(e.Value?.Trim(), "true", StringComparison.OrdinalIgnoreCase));
         }
-        catch
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (XmlException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
         {
             return false;
         }

--- a/DotNetMcp/Resources/ResourceSubscriptionManager.cs
+++ b/DotNetMcp/Resources/ResourceSubscriptionManager.cs
@@ -22,6 +22,7 @@ public class ResourceSubscriptionManager
         "dotnet://runtime-info",
         "dotnet://templates",
         "dotnet://frameworks",
+        "dotnet://workspace",
         "dotnet://telemetry-data",
     };
 

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Misc.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Misc.cs
@@ -58,6 +58,7 @@ public sealed partial class DotNetCliTools
                 "sdk",
                 "security",
                 "framework",
+                "workspace",
                 "format",
                 "nuget",
                 "help",
@@ -110,7 +111,7 @@ public sealed partial class DotNetCliTools
 
         result.AppendLine("FEATURES:");
         result.AppendLine("  • 12 Consolidated MCP Tools (8 functional + 4 utility)");
-        result.AppendLine("  • 4 MCP Resources (SDK, Runtime, Templates, Frameworks)");
+        result.AppendLine("  • 5 MCP Resources (SDK, Runtime, Templates, Frameworks, Workspace)");
         result.AppendLine("  • 3 Predefined Prompts (create_new_webapi, add_package_and_restore, run_tests_with_coverage)");
         result.AppendLine("  • Completion handler: argument autocomplete for templates, frameworks, configurations, and runtime identifiers");
         result.AppendLine("  • Elicitation support: confirmation dialogs for destructive operations (Clean, solution Remove)");
@@ -166,6 +167,7 @@ public sealed partial class DotNetCliTools
         result.AppendLine("  • dotnet://runtime-info - Installed runtimes with metadata");
         result.AppendLine("  • dotnet://templates - Complete template catalog");
         result.AppendLine("  • dotnet://frameworks - Framework information with LTS status");
+        result.AppendLine("  • dotnet://workspace - Workspace solution/project snapshot with TFMs and package counts");
         result.AppendLine();
 
         result.AppendLine("PROMPTS (Predefined Workflow Guides):");

--- a/DotNetMcp/Tools/Sdk/DotNetCliTools.Sdk.Consolidated.cs
+++ b/DotNetMcp/Tools/Sdk/DotNetCliTools.Sdk.Consolidated.cs
@@ -343,7 +343,7 @@ public sealed partial class DotNetCliTools
             await _subscriptions.SendResourceUpdatedAsync(server, "dotnet://workspace");
         }
 
-        return "All caches (templates, SDK, runtime) and metrics cleared successfully. Next query will reload from disk.";
+        return "All caches (templates, SDK, runtime, workspace) and metrics cleared successfully. Next query will reload from disk.";
     }
 
     /// <summary>

--- a/DotNetMcp/Tools/Sdk/DotNetCliTools.Sdk.Consolidated.cs
+++ b/DotNetMcp/Tools/Sdk/DotNetCliTools.Sdk.Consolidated.cs
@@ -340,6 +340,7 @@ public sealed partial class DotNetCliTools
             await _subscriptions.SendResourceUpdatedAsync(server, "dotnet://templates");
             // dotnet://frameworks derives its framework list from the SDK cache, so notify it too.
             await _subscriptions.SendResourceUpdatedAsync(server, "dotnet://frameworks");
+            await _subscriptions.SendResourceUpdatedAsync(server, "dotnet://workspace");
         }
 
         return "All caches (templates, SDK, runtime) and metrics cleared successfully. Next query will reload from disk.";
@@ -441,6 +442,7 @@ public sealed partial class DotNetCliTools
         result.AppendLine($"Templates: {TemplateEngineHelper.Metrics}");
         result.AppendLine($"SDK Info: {DotNetResources.GetSdkMetrics()}");
         result.AppendLine($"Runtime Info: {DotNetResources.GetRuntimeMetrics()}");
+        result.AppendLine($"Workspace: {DotNetResources.GetWorkspaceMetrics()}");
         return Task.FromResult(result.ToString());
     }
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ MCP Resources provide read-only access to structured metadata about your .NET en
 - **dotnet://runtime-info** - Information about installed .NET runtimes (versions and types)
 - **dotnet://templates** - Complete catalog of installed .NET templates with metadata
 - **dotnet://frameworks** - Information about supported .NET frameworks (TFMs) including LTS status
+- **dotnet://workspace** - Workspace snapshot with solution, projects, target frameworks, and package counts
 
 This enables AI assistants to:
 
@@ -227,7 +228,7 @@ dotnet-mcp uses the official [MCP C# SDK](https://csharp.sdk.modelcontextprotoco
 
 | Feature | How dotnet-mcp uses it | Why |
 | ------- | ---------------------- | --- |
-| [Resources](https://modelcontextprotocol.io/specification/latest/server/resources) | Exposes `dotnet://sdk-info`, `dotnet://runtime-info`, `dotnet://templates`, and `dotnet://frameworks` as read-only MCP resources. | Lets clients answer environment questions quickly without shelling out, and reduces token churn from repeated CLI discovery. |
+| [Resources](https://modelcontextprotocol.io/specification/latest/server/resources) | Exposes `dotnet://sdk-info`, `dotnet://runtime-info`, `dotnet://templates`, `dotnet://frameworks`, and `dotnet://workspace` as read-only MCP resources. | Lets clients answer environment and workspace topology questions quickly without shelling out, and reduces token churn from repeated CLI discovery. |
 | [Prompts](https://modelcontextprotocol.io/specification/latest/server/prompts) | Publishes reusable prompts such as `create_new_webapi`, `add_package_and_restore`, and `run_tests_with_coverage`. | Gives MCP clients guided, discoverable workflows instead of rebuilding common prompt scaffolding from scratch. |
 | [Roots](https://modelcontextprotocol.io/specification/latest/client/roots) | Uses client workspace roots to auto-detect a single project or solution when the user omits an explicit path. | Improves out-of-box behavior in IDE clients and reduces the number of parameters users need to supply. |
 | [Sampling](https://modelcontextprotocol.io/specification/latest/client/sampling) | Requests client-mediated LLM summaries for build and test failures when the client supports sampling. | Keeps intelligent diagnostics inside the MCP flow without requiring separate server-side model credentials. |
@@ -740,6 +741,7 @@ The server exposes read-only resources that provide efficient access to .NET env
 - **dotnet://runtime-info** - Information about installed .NET runtimes (versions and types)
 - **dotnet://templates** - Complete catalog of installed .NET templates with metadata
 - **dotnet://frameworks** - Information about supported .NET frameworks (TFMs) including LTS status
+- **dotnet://workspace** - Workspace snapshot with solution, projects, target frameworks, and package counts
 
 Resources provide structured JSON data and are more efficient than tool calls for frequently accessed read-only information.
 

--- a/doc/sdk-integration.md
+++ b/doc/sdk-integration.md
@@ -299,6 +299,12 @@ Framework metadata is also provided via `dotnet_sdk`:
 - Returns JSON with framework information (not cached)
 - Provides static metadata about .NET TFMs
 
+**`dotnet://workspace`**
+
+- Returns JSON snapshot of the current workspace topology
+- Includes solution path (if present), project list, target frameworks, package counts, and test-project hints
+- Cached for 60 seconds to reduce repeated discovery round-trips while keeping project metadata fresh
+
 ### Cache Response Format
 
 All cached resources include metadata:


### PR DESCRIPTION
## Summary
Implements #448 by adding a new read-only MCP resource: dotnet://workspace.

This resource returns a compact, cached workspace snapshot for AI assistants, reducing multi-step discovery round-trips.

## What's included
- Adds dotnet://workspace in DotNetResources with a 60-second cache
- Snapshot shape includes:
  - solution (if present)
  - projects[] with 
ame, path, 	argetFrameworks, packageCount, isTestProject
  - generatedAt
- Adds parsing/discovery helpers to build snapshot from .sln/.slnx and .csproj
- Registers dotnet://workspace in ResourceSubscriptionManager.KnownResourceUris
- Adds workspace cache metric output in dotnet_sdk cache metrics
- Sends resource update notifications for dotnet://workspace when caches are cleared
- Updates human-readable server info and docs (README.md, doc/sdk-integration.md)
- Adds tests:
  - WorkspaceSnapshotResourceTests
  - Updated known-URI test in ResourceSubscriptionManagerTests

## Validation
- dotnet build DotNetMcp/DotNetMcp.csproj
- targeted tests for resources/server-info/template-cache paths all passed

Closes #448