### PR TITLE
feat: estimate and report workflow-level token savings (MCP vs non-MCP baseline)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "10.0.8",
+      "version": "8.0.0",
       "commands": [
         "dotnet-ef"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "8.0.0",
+      "version": "10.0.8",
       "commands": [
         "dotnet-ef"
       ],

--- a/DotNetMcp.Tests/Server/ServerCapabilitiesTests.cs
+++ b/DotNetMcp.Tests/Server/ServerCapabilitiesTests.cs
@@ -159,6 +159,19 @@ public class ServerCapabilitiesTests
     }
 
     [Fact]
+    public async Task DotnetServerCapabilities_Supports_TokenSavings_IsTrue()
+    {
+        var result = (await _tools.DotnetServerCapabilities()).GetText();
+        var jsonDoc = JsonDocument.Parse(result);
+        var tokenSavings = jsonDoc.RootElement
+            .GetProperty("supports")
+            .GetProperty("tokenSavings")
+            .GetBoolean();
+
+        Assert.True(tokenSavings);
+    }
+
+    [Fact]
     public async Task DotnetServerCapabilities_SdkVersions_ContainsInstalledSdks()
     {
         // Act

--- a/DotNetMcp.Tests/Telemetry/TokenSavingsEstimatorTests.cs
+++ b/DotNetMcp.Tests/Telemetry/TokenSavingsEstimatorTests.cs
@@ -1,0 +1,197 @@
+using DotNetMcp;
+using Xunit;
+
+namespace DotNetMcp.Tests;
+
+public class TokenSavingsEstimatorTests
+{
+    [Fact]
+    public void EstimateWorkflow_RollsUpTotalsAndSteps()
+    {
+        var estimator = new TokenSavingsEstimator();
+        var steps = new[]
+        {
+            new TokenSavingsStepInput
+            {
+                StepId = "step-1",
+                StepLabel = "Create project",
+                ToolName = "dotnet_project",
+                StepKind = "discovery",
+                PromptText = "Create a console app",
+                ToolArgumentsJson = "{\"template\":\"console\"}",
+                ToolResponseText = "Project created"
+            }
+        };
+
+        var estimate = estimator.EstimateWorkflow("create-project-package-build", steps);
+
+        Assert.Equal("create-project-package-build", estimate.WorkflowId);
+        Assert.Single(estimate.Steps);
+        Assert.Equal("v1", estimate.AssumptionsProfile.AssumptionsVersion);
+        Assert.True(estimate.McpEstimatedTokens > 0);
+        Assert.True(estimate.BaselineEstimatedTokens > estimate.McpEstimatedTokens);
+        Assert.Equal(estimate.BaselineEstimatedTokens - estimate.McpEstimatedTokens, estimate.EstimatedSavingsTokens);
+        Assert.InRange(estimate.EstimatedSavingsPercent, 0, 100);
+    }
+
+    [Fact]
+    public void EstimateWorkflow_UsesFallbackVersionWhenRequested()
+    {
+        var estimator = new TokenSavingsEstimator();
+        var estimate = estimator.EstimateWorkflow(
+            "run-tests-summarize-failures",
+            [new TokenSavingsStepInput { StepId = "step-1", StepKind = "outputParsing", PromptText = "Run tests" }],
+            assumptionsVersion: "v2");
+
+        Assert.Equal("v2", estimate.AssumptionsProfile.AssumptionsVersion);
+        Assert.Contains("Fallback profile", estimate.AssumptionsProfile.AssumptionsNotes ?? string.Empty);
+    }
+
+    [Fact]
+    public void EstimateStep_UsesMeasuredTokensForHighConfidence()
+    {
+        var estimator = new TokenSavingsEstimator();
+        var step = estimator.EstimateStep(
+            "scaffold-webapi-ef-setup",
+            new TokenSavingsStepInput
+            {
+                StepId = "step-1",
+                StepKind = "manualDiscovery",
+                MeasuredMcpTokens = 120,
+                MeasuredBaselineTokens = 420
+            });
+
+        Assert.Equal("high", step.Confidence);
+        Assert.Equal(420, step.BaselineEstimatedTokens);
+        Assert.Equal(120, step.McpEstimatedTokens);
+        Assert.Equal(300, step.EstimatedSavingsTokens);
+    }
+
+    [Fact]
+    public void TokenSavingsAccumulator_StoresAndResetsSnapshots()
+    {
+        var accumulator = new TokenSavingsAccumulator();
+        var profile = TokenSavingsAssumptionsProfile.CreateDefault();
+        accumulator.RecordWorkflow(new TokenSavingsWorkflowEstimate
+        {
+            WorkflowId = "create-project-package-build",
+            McpEstimatedTokens = 10,
+            BaselineEstimatedTokens = 40,
+            EstimatedSavingsTokens = 30,
+            EstimatedSavingsPercent = 75.0,
+            Confidence = "low",
+            AssumptionsProfile = profile,
+            Steps = []
+        });
+
+        var snapshot = accumulator.GetSnapshot();
+
+        Assert.Single(snapshot);
+        Assert.True(snapshot.ContainsKey("create-project-package-build"));
+
+        accumulator.Reset();
+
+        Assert.Empty(accumulator.GetSnapshot());
+    }
+
+    // -------------------------------------------------------------------------
+    // Model-family tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void EstimateWorkflow_ModelFamily_SurfacedOnEstimate()
+    {
+        var estimator = new TokenSavingsEstimator(defaultModelFamily: ModelFamily.ClaudeSonnet);
+        var steps = new[]
+        {
+            new TokenSavingsStepInput { StepId = "s1", StepKind = "normal", PromptText = "Do something" }
+        };
+
+        var estimate = estimator.EstimateWorkflow("create-project-package-build", steps);
+
+        Assert.Equal(ModelFamily.ClaudeSonnet, estimate.ModelFamilyUsed);
+        Assert.Equal(ModelFamily.ClaudeSonnet, estimate.Steps[0].ModelFamilyUsed);
+    }
+
+    [Fact]
+    public void EstimateWorkflow_PerStepModelOverrideWins()
+    {
+        var estimator = new TokenSavingsEstimator(defaultModelFamily: ModelFamily.OpenAiGpt4O);
+        var steps = new[]
+        {
+            new TokenSavingsStepInput
+            {
+                StepId = "s1",
+                StepKind = "normal",
+                PromptText = "Do something",
+                ModelFamily = ModelFamily.ClaudeHaiku
+            }
+        };
+
+        var estimate = estimator.EstimateWorkflow("create-project-package-build", steps);
+
+        Assert.Equal(ModelFamily.ClaudeHaiku, estimate.Steps[0].ModelFamilyUsed);
+    }
+
+    [Theory]
+    [InlineData(ModelFamily.OpenAiO1)]
+    [InlineData(ModelFamily.ClaudeHaiku)]
+    public void EstimateWorkflow_DifferentModels_ProduceDifferentBaselineTokens(ModelFamily family)
+    {
+        // o1 has a higher BaselineScaleFactor (1.8), Haiku a lower one (0.85).
+        // Both should differ from the Unknown baseline (scale factor 1.0).
+        static TokenSavingsWorkflowEstimate Run(ModelFamily f) =>
+            new TokenSavingsEstimator(defaultModelFamily: f)
+                .EstimateWorkflow("scaffold-webapi-ef-setup",
+                [
+                    new TokenSavingsStepInput
+                    {
+                        StepId = "s1", StepKind = "discovery",
+                        PromptText = "Create a web API with EF Core",
+                        ToolArgumentsJson = "{\"template\":\"webapi\"}"
+                    }
+                ]);
+
+        Assert.NotEqual(Run(ModelFamily.Unknown).BaselineEstimatedTokens, Run(family).BaselineEstimatedTokens);
+    }
+
+    // -------------------------------------------------------------------------
+    // Content-kind detection tests
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("{\"key\":\"value\",\"n\":42}", ContentKind.Json)]
+    [InlineData("[\"a\",\"b\",\"c\"]", ContentKind.Json)]
+    [InlineData("public void Foo() { return; }", ContentKind.Code)]
+    [InlineData("if (x > 0) { DoSomething(); }", ContentKind.Code)]
+    [InlineData("Create a console application that prints Hello World.", ContentKind.Prose)]
+    [InlineData("Run tests and summarize failures for the test suite.", ContentKind.Prose)]
+    public void DetectContentKind_ReturnsExpectedKind(string text, ContentKind expected)
+    {
+        Assert.Equal(expected, TokenSavingsEstimator.DetectContentKind(text));
+    }
+
+    // -------------------------------------------------------------------------
+    // ParseModelId tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ParseModelId_MapsKnownModelIds()
+    {
+        Assert.Equal(ModelFamily.OpenAiGpt4O,  TokenizerApproximation.ParseModelId("gpt-4o-2024-08-06"));
+        Assert.Equal(ModelFamily.OpenAiGpt4,   TokenizerApproximation.ParseModelId("gpt-4-turbo"));
+        Assert.Equal(ModelFamily.OpenAiO1,     TokenizerApproximation.ParseModelId("o1-preview"));
+        Assert.Equal(ModelFamily.OpenAiO1,     TokenizerApproximation.ParseModelId("o3-mini"));
+        Assert.Equal(ModelFamily.ClaudeSonnet, TokenizerApproximation.ParseModelId("claude-3-5-sonnet-20241022"));
+        Assert.Equal(ModelFamily.ClaudeSonnet, TokenizerApproximation.ParseModelId("claude-sonnet-4-5"));
+        Assert.Equal(ModelFamily.ClaudeOpus,   TokenizerApproximation.ParseModelId("claude-3-opus-20240229"));
+        Assert.Equal(ModelFamily.ClaudeHaiku,  TokenizerApproximation.ParseModelId("claude-3-haiku-20240307"));
+        Assert.Equal(ModelFamily.GeminiFlash,  TokenizerApproximation.ParseModelId("gemini-1.5-flash"));
+        Assert.Equal(ModelFamily.GeminiPro,    TokenizerApproximation.ParseModelId("gemini-2.0-pro"));
+        Assert.Equal(ModelFamily.Llama3,       TokenizerApproximation.ParseModelId("llama-3.1-70b"));
+        Assert.Equal(ModelFamily.Mistral,      TokenizerApproximation.ParseModelId("mistral-large-latest"));
+        Assert.Equal(ModelFamily.Mistral,      TokenizerApproximation.ParseModelId("mixtral-8x7b"));
+        Assert.Equal(ModelFamily.Unknown,      TokenizerApproximation.ParseModelId(null));
+        Assert.Equal(ModelFamily.Unknown,      TokenizerApproximation.ParseModelId("some-future-model-xyz"));
+    }
+}

--- a/DotNetMcp.Tests/Tools/ServerMetricsToolTests.cs
+++ b/DotNetMcp.Tests/Tools/ServerMetricsToolTests.cs
@@ -132,6 +132,7 @@ public class ServerMetricsToolTests
         Assert.Equal(0, root.GetProperty("totalInvocations").GetInt64());
         Assert.Equal(0, root.GetProperty("totalSuccesses").GetInt64());
         Assert.Equal(0, root.GetProperty("totalFailures").GetInt64());
+        Assert.False(root.GetProperty("tokenSavingsEnabled").GetBoolean());
     }
 
     [Fact]

--- a/DotNetMcp/Actions/DotnetActions.cs
+++ b/DotNetMcp/Actions/DotnetActions.cs
@@ -313,6 +313,12 @@ public enum DotnetServerMetricsAction
     /// <summary>Return a JSON snapshot of per-tool invocation counts, average durations, and success/failure counts</summary>
     Get,
 
+    /// <summary>Return workflow-level token savings estimates</summary>
+    TokenSavingsGet,
+
+    /// <summary>Reset accumulated token savings estimates</summary>
+    TokenSavingsReset,
+
     /// <summary>Reset all accumulated metrics to zero</summary>
     Reset
 }

--- a/DotNetMcp/DotNetMcp.csproj
+++ b/DotNetMcp/DotNetMcp.csproj
@@ -43,6 +43,8 @@
     <None Include="$(IntermediateOutputPath)mcp/server.json" Pack="true" PackagePath="/.mcp/" Visible="false" />
     <!-- Include ErrorCodes.json as embedded resource -->
     <EmbeddedResource Include="Errors/ErrorCodes.json" />
+    <!-- Include token savings default assumptions profile as embedded resource -->
+    <EmbeddedResource Include="Telemetry/Profiles/TokenSavingsProfile.Default.v1.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DotNetMcp/Program.cs
+++ b/DotNetMcp/Program.cs
@@ -31,6 +31,12 @@ builder.Services.AddSingleton<IMcpTaskStore, InMemoryMcpTaskStore>();
 var metricsAccumulator = new ToolMetricsAccumulator();
 builder.Services.AddSingleton(metricsAccumulator);
 
+// Register token savings estimation services.
+var tokenSavingsAccumulator = new TokenSavingsAccumulator();
+var tokenSavingsEstimator = new TokenSavingsEstimator();
+builder.Services.AddSingleton(tokenSavingsAccumulator);
+builder.Services.AddSingleton(tokenSavingsEstimator);
+
 // Register ResourceSubscriptionManager for tracking client resource subscriptions.
 builder.Services.AddSingleton<ResourceSubscriptionManager>();
 

--- a/DotNetMcp/Server/ServerCapabilities.cs
+++ b/DotNetMcp/Server/ServerCapabilities.cs
@@ -134,6 +134,12 @@ public sealed class ServerFeatureSupport
     /// </summary>
     [JsonPropertyName("progressNotifications")]
     public bool ProgressNotifications { get; init; }
+
+    /// <summary>
+    /// Whether the server exposes workflow-level token savings estimation and reporting.
+    /// </summary>
+    [JsonPropertyName("tokenSavings")]
+    public bool TokenSavings { get; init; }
 }
 
 /// <summary>

--- a/DotNetMcp/Telemetry/Profiles/TokenSavingsProfile.Default.v1.json
+++ b/DotNetMcp/Telemetry/Profiles/TokenSavingsProfile.Default.v1.json
@@ -1,0 +1,30 @@
+{
+  "assumptionsVersion": "v1",
+  "assumptionsNotes": "Heuristic baseline profiles with a 4-char-per-token approximation for MCP payloads.",
+  "workflows": {
+    "create-project-package-build": {
+      "discoveryTurns": 2,
+      "retryTurns": 1,
+      "outputParsingTurns": 1,
+      "manualDiscoveryTurns": 1,
+      "tokensPerTurn": 350,
+      "notes": "Project creation + package add + build typically requires a small amount of discovery and one retry when package or template parameters are missing."
+    },
+    "run-tests-summarize-failures": {
+      "discoveryTurns": 1,
+      "retryTurns": 1,
+      "outputParsingTurns": 2,
+      "manualDiscoveryTurns": 1,
+      "tokensPerTurn": 300,
+      "notes": "Test failure workflows pay more parsing cost because raw output is verbose and failure triage is iterative."
+    },
+    "scaffold-webapi-ef-setup": {
+      "discoveryTurns": 2,
+      "retryTurns": 1,
+      "outputParsingTurns": 1,
+      "manualDiscoveryTurns": 2,
+      "tokensPerTurn": 375,
+      "notes": "Web API plus EF setup often includes template discovery, package selection, and user-secrets guidance."
+    }
+  }
+}

--- a/DotNetMcp/Telemetry/TokenSavingsAccumulator.cs
+++ b/DotNetMcp/Telemetry/TokenSavingsAccumulator.cs
@@ -1,0 +1,21 @@
+using System.Collections.Concurrent;
+
+namespace DotNetMcp;
+
+/// <summary>
+/// Thread-safe accumulator for token savings estimates grouped by workflow id.
+/// </summary>
+public sealed class TokenSavingsAccumulator
+{
+    private readonly ConcurrentDictionary<string, TokenSavingsWorkflowEstimate> _workflows = new(StringComparer.OrdinalIgnoreCase);
+
+    public void RecordWorkflow(TokenSavingsWorkflowEstimate estimate)
+    {
+        _workflows[estimate.WorkflowId] = estimate;
+    }
+
+    public IReadOnlyDictionary<string, TokenSavingsWorkflowEstimate> GetSnapshot()
+        => _workflows.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+
+    public void Reset() => _workflows.Clear();
+}

--- a/DotNetMcp/Telemetry/TokenSavingsEstimator.cs
+++ b/DotNetMcp/Telemetry/TokenSavingsEstimator.cs
@@ -136,7 +136,7 @@ public sealed class TokenSavingsEstimator
     internal static long EstimateTokens(TokenizerApproximation tokenizer, params string?[] parts)
     {
         long total = 0;
-        foreach (var part in parts.Where(p => !string.IsNullOrEmpty(p)))
+        foreach (var part in parts.OfType<string>().Where(p => p.Length > 0))
         {
             var charsPerToken = DetectContentKind(part) switch
             {
@@ -144,7 +144,7 @@ public sealed class TokenSavingsEstimator
                 ContentKind.Code => tokenizer.CodeCharsPerToken,
                 _                => tokenizer.ProseCharsPerToken
             };
-            total += (long)Math.Ceiling(part!.Length / charsPerToken);
+            total += (long)Math.Ceiling(part.Length / charsPerToken);
         }
         return total;
     }

--- a/DotNetMcp/Telemetry/TokenSavingsEstimator.cs
+++ b/DotNetMcp/Telemetry/TokenSavingsEstimator.cs
@@ -8,6 +8,9 @@ public sealed class TokenSavingsEstimator
     private readonly TokenSavingsAssumptionsProfile _defaultProfile;
     private readonly ModelFamily _defaultModelFamily;
 
+    /// <summary>
+    /// Initialises a new <see cref="TokenSavingsEstimator"/> with an optional assumptions profile and default model family.
+    /// </summary>
     /// <param name="defaultProfile">Heuristic assumptions profile. Defaults to the v1 built-in profile.</param>
     /// <param name="defaultModelFamily">
     /// Default model family used for tokenizer approximation when not supplied per-step.
@@ -21,6 +24,9 @@ public sealed class TokenSavingsEstimator
         _defaultModelFamily = defaultModelFamily;
     }
 
+    /// <summary>
+    /// Estimates token savings for a complete workflow by aggregating per-step estimates.
+    /// </summary>
     /// <param name="modelFamily">
     /// Optional model family override for this workflow. Falls back to the constructor default.
     /// Can be further overridden per-step via <see cref="TokenSavingsStepInput.ModelFamily"/>.
@@ -130,16 +136,15 @@ public sealed class TokenSavingsEstimator
     internal static long EstimateTokens(TokenizerApproximation tokenizer, params string?[] parts)
     {
         long total = 0;
-        foreach (var part in parts)
+        foreach (var part in parts.Where(p => !string.IsNullOrEmpty(p)))
         {
-            if (string.IsNullOrEmpty(part)) continue;
             var charsPerToken = DetectContentKind(part) switch
             {
                 ContentKind.Json => tokenizer.JsonCharsPerToken,
                 ContentKind.Code => tokenizer.CodeCharsPerToken,
                 _                => tokenizer.ProseCharsPerToken
             };
-            total += (long)Math.Ceiling(part.Length / charsPerToken);
+            total += (long)Math.Ceiling(part!.Length / charsPerToken);
         }
         return total;
     }

--- a/DotNetMcp/Telemetry/TokenSavingsEstimator.cs
+++ b/DotNetMcp/Telemetry/TokenSavingsEstimator.cs
@@ -1,0 +1,211 @@
+namespace DotNetMcp;
+
+/// <summary>
+/// Estimates token usage and token savings for a workflow.
+/// </summary>
+public sealed class TokenSavingsEstimator
+{
+    private readonly TokenSavingsAssumptionsProfile _defaultProfile;
+    private readonly ModelFamily _defaultModelFamily;
+
+    /// <param name="defaultProfile">Heuristic assumptions profile. Defaults to the v1 built-in profile.</param>
+    /// <param name="defaultModelFamily">
+    /// Default model family used for tokenizer approximation when not supplied per-step.
+    /// Defaults to <see cref="ModelFamily.Unknown"/> (universal 4 chars/token fallback).
+    /// </param>
+    public TokenSavingsEstimator(
+        TokenSavingsAssumptionsProfile? defaultProfile = null,
+        ModelFamily defaultModelFamily = ModelFamily.Unknown)
+    {
+        _defaultProfile = defaultProfile ?? TokenSavingsAssumptionsProfile.CreateDefault();
+        _defaultModelFamily = defaultModelFamily;
+    }
+
+    /// <param name="modelFamily">
+    /// Optional model family override for this workflow. Falls back to the constructor default.
+    /// Can be further overridden per-step via <see cref="TokenSavingsStepInput.ModelFamily"/>.
+    /// </param>
+    public TokenSavingsWorkflowEstimate EstimateWorkflow(
+        string workflowId,
+        IReadOnlyCollection<TokenSavingsStepInput> steps,
+        string? assumptionsVersion = null,
+        ModelFamily? modelFamily = null)
+    {
+        var profile = ResolveProfile(assumptionsVersion);
+        var workflowFamily = modelFamily ?? _defaultModelFamily;
+        var estimatedSteps = steps.Select(step => EstimateStep(workflowId, step, profile, workflowFamily)).ToArray();
+
+        var mcpEstimatedTokens = estimatedSteps.Sum(step => step.McpEstimatedTokens);
+        var baselineEstimatedTokens = estimatedSteps.Sum(step => step.BaselineEstimatedTokens);
+        var savingsTokens = baselineEstimatedTokens - mcpEstimatedTokens;
+        var savingsPercent = baselineEstimatedTokens > 0
+            ? Math.Round((double)savingsTokens / baselineEstimatedTokens * 100.0, 1)
+            : 0.0;
+
+        // Surface the effective model family: unanimous if all steps agree, Unknown if mixed.
+        var effectiveFamily = estimatedSteps.Length > 0 && estimatedSteps.All(s => s.ModelFamilyUsed == estimatedSteps[0].ModelFamilyUsed)
+            ? estimatedSteps[0].ModelFamilyUsed
+            : ModelFamily.Unknown;
+
+        return new TokenSavingsWorkflowEstimate
+        {
+            WorkflowId = workflowId,
+            ModelFamilyUsed = effectiveFamily,
+            McpEstimatedTokens = mcpEstimatedTokens,
+            BaselineEstimatedTokens = baselineEstimatedTokens,
+            EstimatedSavingsTokens = savingsTokens,
+            EstimatedSavingsPercent = savingsPercent,
+            Confidence = CombineConfidence(estimatedSteps.Select(step => step.Confidence)),
+            AssumptionsProfile = profile,
+            Steps = estimatedSteps
+        };
+    }
+
+    public TokenSavingsStepEstimate EstimateStep(
+        string workflowId,
+        TokenSavingsStepInput input,
+        TokenSavingsAssumptionsProfile? profileOverride = null,
+        ModelFamily? workflowFamilyOverride = null)
+    {
+        var profile = profileOverride ?? ResolveProfile(null);
+        var family = input.ModelFamily ?? workflowFamilyOverride ?? _defaultModelFamily;
+        var tokenizer = TokenizerApproximation.For(family);
+
+        var mcpEstimatedTokens = input.MeasuredMcpTokens
+            ?? EstimateTokens(tokenizer, input.PromptText, input.ToolArgumentsJson, input.ToolResponseText, input.StructuredContentJson);
+        var heuristics = ResolveHeuristics(profile, workflowId);
+        var baselineEstimatedTokens = input.MeasuredBaselineTokens
+            ?? (mcpEstimatedTokens + EstimateBaselineOverhead(heuristics, input.StepKind, tokenizer));
+        var savingsTokens = baselineEstimatedTokens - mcpEstimatedTokens;
+        var savingsPercent = baselineEstimatedTokens > 0
+            ? Math.Round((double)savingsTokens / baselineEstimatedTokens * 100.0, 1)
+            : 0.0;
+
+        return new TokenSavingsStepEstimate
+        {
+            StepId = input.StepId,
+            StepLabel = input.StepLabel,
+            ToolName = input.ToolName,
+            ModelFamilyUsed = family,
+            McpEstimatedTokens = mcpEstimatedTokens,
+            BaselineEstimatedTokens = baselineEstimatedTokens,
+            EstimatedSavingsTokens = savingsTokens,
+            EstimatedSavingsPercent = savingsPercent,
+            Confidence = ResolveConfidence(input),
+            AssumptionsProfile = profile
+        };
+    }
+
+    private TokenSavingsAssumptionsProfile ResolveProfile(string? assumptionsVersion)
+    {
+        if (string.IsNullOrWhiteSpace(assumptionsVersion) || string.Equals(assumptionsVersion, _defaultProfile.AssumptionsVersion, StringComparison.OrdinalIgnoreCase))
+            return _defaultProfile;
+
+        return new TokenSavingsAssumptionsProfile
+        {
+            AssumptionsVersion = assumptionsVersion,
+            AssumptionsNotes = $"Fallback profile for unknown version '{assumptionsVersion}'.",
+            Workflows = _defaultProfile.Workflows
+        };
+    }
+
+    private static TokenSavingsWorkflowHeuristics ResolveHeuristics(TokenSavingsAssumptionsProfile profile, string workflowId)
+        => profile.Workflows.TryGetValue(workflowId, out var heuristics)
+            ? heuristics
+            : new TokenSavingsWorkflowHeuristics
+            {
+                DiscoveryTurns = 1,
+                RetryTurns = 1,
+                OutputParsingTurns = 1,
+                ManualDiscoveryTurns = 1,
+                TokensPerTurn = 300,
+                Notes = "Default heuristic fallback"
+            };
+
+    /// <summary>
+    /// Estimates tokens for a set of text parts using the provided tokenizer approximation.
+    /// Each part is sniffed for content kind (JSON, code, or prose) and the appropriate
+    /// chars-per-token ratio is applied independently.
+    /// </summary>
+    internal static long EstimateTokens(TokenizerApproximation tokenizer, params string?[] parts)
+    {
+        long total = 0;
+        foreach (var part in parts)
+        {
+            if (string.IsNullOrEmpty(part)) continue;
+            var charsPerToken = DetectContentKind(part) switch
+            {
+                ContentKind.Json => tokenizer.JsonCharsPerToken,
+                ContentKind.Code => tokenizer.CodeCharsPerToken,
+                _                => tokenizer.ProseCharsPerToken
+            };
+            total += (long)Math.Ceiling(part.Length / charsPerToken);
+        }
+        return total;
+    }
+
+    /// <summary>
+    /// Heuristically detects whether a text payload looks like JSON, source code, or prose.
+    /// Used to select the correct chars-per-token ratio for that content type.
+    /// </summary>
+    internal static ContentKind DetectContentKind(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return ContentKind.Prose;
+
+        var trimmed = text.TrimStart();
+
+        // JSON objects or arrays
+        if (trimmed.StartsWith('{') || trimmed.StartsWith('['))
+            return ContentKind.Json;
+
+        // Code heuristic: high density of code-punctuation relative to length
+        var codePunct = text.Count(c => c is '{' or '}' or '(' or ')' or ';' or '<' or '>');
+        if (codePunct > text.Length * 0.04)
+            return ContentKind.Code;
+
+        return ContentKind.Prose;
+    }
+
+    private static long EstimateBaselineOverhead(
+        TokenSavingsWorkflowHeuristics heuristics,
+        string stepKind,
+        TokenizerApproximation tokenizer)
+    {
+        // Apply the model-family baseline scale factor to the per-turn token estimate.
+        var tokensPerTurn = (long)Math.Ceiling(heuristics.TokensPerTurn * tokenizer.BaselineScaleFactor);
+        return stepKind.Trim().ToLowerInvariant() switch
+        {
+            "discovery"       => heuristics.DiscoveryTurns * tokensPerTurn,
+            "retry"           => heuristics.RetryTurns * tokensPerTurn,
+            "outputparsing"   => heuristics.OutputParsingTurns * tokensPerTurn,
+            "manualdiscovery" => heuristics.ManualDiscoveryTurns * tokensPerTurn,
+            _                 => tokensPerTurn
+        };
+    }
+
+    private static string ResolveConfidence(TokenSavingsStepInput input)
+    {
+        if (input.MeasuredMcpTokens.HasValue && input.MeasuredBaselineTokens.HasValue)
+            return "high";
+
+        if (input.MeasuredMcpTokens.HasValue || input.MeasuredBaselineTokens.HasValue)
+            return "medium";
+
+        return "low";
+    }
+
+    private static string CombineConfidence(IEnumerable<string> confidences)
+    {
+        var list = confidences.ToArray();
+        if (list.Length == 0)
+            return "low";
+
+        if (list.All(value => value.Equals("high", StringComparison.OrdinalIgnoreCase)))
+            return "high";
+
+        if (list.Any(value => value.Equals("medium", StringComparison.OrdinalIgnoreCase)))
+            return "medium";
+
+        return "low";
+    }
+}

--- a/DotNetMcp/Telemetry/TokenSavingsModels.cs
+++ b/DotNetMcp/Telemetry/TokenSavingsModels.cs
@@ -180,7 +180,11 @@ public sealed class TokenSavingsAssumptionsProfile
                     return loaded;
             }
         }
-        catch (Exception)
+        catch (IOException)
+        {
+            // Fall through to hard-coded defaults
+        }
+        catch (JsonException)
         {
             // Fall through to hard-coded defaults
         }

--- a/DotNetMcp/Telemetry/TokenSavingsModels.cs
+++ b/DotNetMcp/Telemetry/TokenSavingsModels.cs
@@ -1,0 +1,331 @@
+using System.Text.Json.Serialization;
+
+namespace DotNetMcp;
+
+/// <summary>
+/// The broad family of LLM a caller is using. Controls which tokenizer approximation
+/// and baseline scale factor are applied during token savings estimation.
+/// </summary>
+public enum ModelFamily
+{
+    /// <summary>No model specified; uses the universal 4 chars/token fallback.</summary>
+    Unknown = 0,
+    /// <summary>GPT-4 (non-omni) — cl100k_base tokenizer.</summary>
+    OpenAiGpt4,
+    /// <summary>GPT-4o and GPT-4o-mini — cl100k_base tokenizer, similar ratios to GPT-4.</summary>
+    OpenAiGpt4O,
+    /// <summary>OpenAI o1 / o3 reasoning models — same tokenizer but much higher baseline cost due to thinking tokens.</summary>
+    OpenAiO1,
+    /// <summary>Claude 3 / 3.5 / 4 Sonnet — Anthropic BPE tokenizer.</summary>
+    ClaudeSonnet,
+    /// <summary>Claude 3 / 3.5 Opus — Anthropic BPE tokenizer.</summary>
+    ClaudeOpus,
+    /// <summary>Claude 3 / 3.5 Haiku — Anthropic BPE tokenizer, more compact responses.</summary>
+    ClaudeHaiku,
+    /// <summary>Gemini Pro family (1.5 Pro, 2.0 Pro) — SentencePiece tokenizer.</summary>
+    GeminiPro,
+    /// <summary>Gemini Flash family — SentencePiece tokenizer, more compact responses.</summary>
+    GeminiFlash,
+    /// <summary>Llama 3 / 3.1 / 3.2 — tiktoken-style tokenizer.</summary>
+    Llama3,
+    /// <summary>Mistral family — SentencePiece tokenizer.</summary>
+    Mistral
+}
+
+/// <summary>
+/// Detected content kind used to pick the right chars-per-token ratio.
+/// </summary>
+public enum ContentKind
+{
+    /// <summary>Plain English prose.</summary>
+    Prose,
+    /// <summary>JSON payload (keys and punctuation split into many tokens).</summary>
+    Json,
+    /// <summary>Source code (brackets, operators, identifiers tokenize densely).</summary>
+    Code
+}
+
+/// <summary>
+/// Per-model-family tokenizer approximation.
+/// Chars-per-token ratios are empirically derived from representative English + developer content.
+/// BaselineScaleFactor adjusts the heuristic TokensPerTurn from the assumptions profile to reflect
+/// how verbose a model family tends to be in a non-MCP (manual) workflow.
+/// </summary>
+public sealed class TokenizerApproximation
+{
+    /// <summary>Average characters per token for plain prose.</summary>
+    public double ProseCharsPerToken { get; init; } = 4.0;
+
+    /// <summary>Average characters per token for JSON payloads.</summary>
+    public double JsonCharsPerToken { get; init; } = 3.5;
+
+    /// <summary>Average characters per token for source code.</summary>
+    public double CodeCharsPerToken { get; init; } = 3.2;
+
+    /// <summary>
+    /// Multiplier applied to the heuristic TokensPerTurn value to account for model verbosity.
+    /// 1.0 = matches the profile baseline exactly. Values above 1.0 mean the model tends to
+    /// produce larger non-MCP turns (e.g., reasoning tokens in o1/o3); below 1.0 means
+    /// more concise models (e.g., Haiku, Flash).
+    /// </summary>
+    public double BaselineScaleFactor { get; init; } = 1.0;
+
+    /// <summary>Well-known approximation profiles keyed by model family.</summary>
+    public static IReadOnlyDictionary<ModelFamily, TokenizerApproximation> WellKnown { get; } =
+        new Dictionary<ModelFamily, TokenizerApproximation>
+        {
+            // cl100k_base: well-studied; ~4 chars/token English prose
+            [ModelFamily.Unknown]       = new() { ProseCharsPerToken = 4.0, JsonCharsPerToken = 3.5, CodeCharsPerToken = 3.2, BaselineScaleFactor = 1.00 },
+            [ModelFamily.OpenAiGpt4]    = new() { ProseCharsPerToken = 4.0, JsonCharsPerToken = 3.5, CodeCharsPerToken = 3.2, BaselineScaleFactor = 1.10 },
+            [ModelFamily.OpenAiGpt4O]   = new() { ProseCharsPerToken = 4.0, JsonCharsPerToken = 3.5, CodeCharsPerToken = 3.2, BaselineScaleFactor = 1.00 },
+            // o1/o3: same external tokenizer, but thinking tokens inflate baseline dramatically
+            [ModelFamily.OpenAiO1]      = new() { ProseCharsPerToken = 4.0, JsonCharsPerToken = 3.5, CodeCharsPerToken = 3.2, BaselineScaleFactor = 1.80 },
+            // Anthropic BPE: produces ~3.7 chars/token for English prose
+            [ModelFamily.ClaudeSonnet]  = new() { ProseCharsPerToken = 3.7, JsonCharsPerToken = 3.3, CodeCharsPerToken = 3.0, BaselineScaleFactor = 0.95 },
+            [ModelFamily.ClaudeOpus]    = new() { ProseCharsPerToken = 3.7, JsonCharsPerToken = 3.3, CodeCharsPerToken = 3.0, BaselineScaleFactor = 1.05 },
+            [ModelFamily.ClaudeHaiku]   = new() { ProseCharsPerToken = 3.7, JsonCharsPerToken = 3.3, CodeCharsPerToken = 3.0, BaselineScaleFactor = 0.85 },
+            // SentencePiece (Gemini): slightly denser for code than cl100k
+            [ModelFamily.GeminiPro]     = new() { ProseCharsPerToken = 3.8, JsonCharsPerToken = 3.4, CodeCharsPerToken = 3.1, BaselineScaleFactor = 1.00 },
+            [ModelFamily.GeminiFlash]   = new() { ProseCharsPerToken = 3.8, JsonCharsPerToken = 3.4, CodeCharsPerToken = 3.1, BaselineScaleFactor = 0.90 },
+            // Llama 3 tiktoken-variant
+            [ModelFamily.Llama3]        = new() { ProseCharsPerToken = 3.5, JsonCharsPerToken = 3.2, CodeCharsPerToken = 3.0, BaselineScaleFactor = 0.95 },
+            // Mistral SentencePiece
+            [ModelFamily.Mistral]       = new() { ProseCharsPerToken = 3.6, JsonCharsPerToken = 3.3, CodeCharsPerToken = 3.1, BaselineScaleFactor = 0.95 },
+        };
+
+    /// <summary>
+    /// Returns the approximation for the given model family,
+    /// falling back to <see cref="ModelFamily.Unknown"/> if not found.
+    /// </summary>
+    public static TokenizerApproximation For(ModelFamily family)
+        => WellKnown.TryGetValue(family, out var profile) ? profile : WellKnown[ModelFamily.Unknown];
+
+    /// <summary>
+    /// Parses a raw model-ID string (e.g. <c>"gpt-4o"</c>, <c>"claude-sonnet-4-5"</c>) into a
+    /// <see cref="ModelFamily"/>. Comparison is case-insensitive; unknown strings return
+    /// <see cref="ModelFamily.Unknown"/>.
+    /// </summary>
+    public static ModelFamily ParseModelId(string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId))
+            return ModelFamily.Unknown;
+
+        var id = modelId.ToLowerInvariant();
+
+        if (id.Contains("o1") || id.Contains("o3") || id.Contains("o4"))
+            return ModelFamily.OpenAiO1;
+        if (id.Contains("gpt-4o") || id.Contains("gpt4o"))
+            return ModelFamily.OpenAiGpt4O;
+        if (id.Contains("gpt-4") || id.Contains("gpt4"))
+            return ModelFamily.OpenAiGpt4;
+        if (id.Contains("claude") && id.Contains("opus"))
+            return ModelFamily.ClaudeOpus;
+        if (id.Contains("claude") && id.Contains("haiku"))
+            return ModelFamily.ClaudeHaiku;
+        if (id.Contains("claude") && (id.Contains("sonnet") || id.Contains("3") || id.Contains("4")))
+            return ModelFamily.ClaudeSonnet;
+        if (id.Contains("gemini") && id.Contains("flash"))
+            return ModelFamily.GeminiFlash;
+        if (id.Contains("gemini"))
+            return ModelFamily.GeminiPro;
+        if (id.Contains("llama"))
+            return ModelFamily.Llama3;
+        if (id.Contains("mistral") || id.Contains("mixtral"))
+            return ModelFamily.Mistral;
+
+        return ModelFamily.Unknown;
+    }
+}
+
+/// <summary>
+/// Versioned assumption profile metadata for token savings estimation.
+/// </summary>
+public sealed class TokenSavingsAssumptionsProfile
+{
+    /// <summary>Version identifier for the assumptions profile.</summary>
+    [JsonPropertyName("assumptionsVersion")]
+    public string AssumptionsVersion { get; init; } = "v1";
+
+    /// <summary>Optional human-readable notes about the assumptions used.</summary>
+    [JsonPropertyName("assumptionsNotes")]
+    public string? AssumptionsNotes { get; init; }
+
+    /// <summary>Workflow-specific heuristic profiles keyed by workflow id.</summary>
+    [JsonPropertyName("workflows")]
+    public Dictionary<string, TokenSavingsWorkflowHeuristics> Workflows { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Creates the default v1 assumptions profile used by the estimator.
+    /// </summary>
+    public static TokenSavingsAssumptionsProfile CreateDefault() => new()
+    {
+        AssumptionsVersion = "v1",
+        AssumptionsNotes = "Heuristic baseline profiles with a 4-char-per-token approximation for MCP payloads.",
+        Workflows = new Dictionary<string, TokenSavingsWorkflowHeuristics>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["create-project-package-build"] = new TokenSavingsWorkflowHeuristics
+            {
+                DiscoveryTurns = 2,
+                RetryTurns = 1,
+                OutputParsingTurns = 1,
+                ManualDiscoveryTurns = 1,
+                TokensPerTurn = 350,
+                Notes = "Project creation + package add + build typically requires a small amount of discovery and one retry when package or template parameters are missing."
+            },
+            ["run-tests-summarize-failures"] = new TokenSavingsWorkflowHeuristics
+            {
+                DiscoveryTurns = 1,
+                RetryTurns = 1,
+                OutputParsingTurns = 2,
+                ManualDiscoveryTurns = 1,
+                TokensPerTurn = 300,
+                Notes = "Test failure workflows pay more parsing cost because raw output is verbose and failure triage is iterative."
+            },
+            ["scaffold-webapi-ef-setup"] = new TokenSavingsWorkflowHeuristics
+            {
+                DiscoveryTurns = 2,
+                RetryTurns = 1,
+                OutputParsingTurns = 1,
+                ManualDiscoveryTurns = 2,
+                TokensPerTurn = 375,
+                Notes = "Web API plus EF setup often includes template discovery, package selection, and user-secrets guidance."
+            }
+        }
+    };
+}
+
+/// <summary>
+/// Workflow-specific heuristic assumptions used to derive baseline token estimates.
+/// </summary>
+public sealed class TokenSavingsWorkflowHeuristics
+{
+    [JsonPropertyName("discoveryTurns")]
+    public int DiscoveryTurns { get; init; }
+
+    [JsonPropertyName("retryTurns")]
+    public int RetryTurns { get; init; }
+
+    [JsonPropertyName("outputParsingTurns")]
+    public int OutputParsingTurns { get; init; }
+
+    [JsonPropertyName("manualDiscoveryTurns")]
+    public int ManualDiscoveryTurns { get; init; }
+
+    [JsonPropertyName("tokensPerTurn")]
+    public int TokensPerTurn { get; init; } = 300;
+
+    [JsonPropertyName("notes")]
+    public string? Notes { get; init; }
+}
+
+/// <summary>
+/// One workflow step used as input to the estimator.
+/// </summary>
+public sealed class TokenSavingsStepInput
+{
+    /// <summary>
+    /// Optional model family hint. When set, overrides the estimator's default and selects
+    /// the appropriate tokenizer approximation for MCP-side token counting and baseline scaling.
+    /// </summary>
+    [JsonPropertyName("modelFamily")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ModelFamily? ModelFamily { get; init; }
+    [JsonPropertyName("stepId")]
+    public string StepId { get; init; } = string.Empty;
+
+    [JsonPropertyName("stepLabel")]
+    public string? StepLabel { get; init; }
+
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; init; }
+
+    [JsonPropertyName("stepKind")]
+    public string StepKind { get; init; } = "normal";
+
+    [JsonPropertyName("promptText")]
+    public string? PromptText { get; init; }
+
+    [JsonPropertyName("toolArgumentsJson")]
+    public string? ToolArgumentsJson { get; init; }
+
+    [JsonPropertyName("toolResponseText")]
+    public string? ToolResponseText { get; init; }
+
+    [JsonPropertyName("structuredContentJson")]
+    public string? StructuredContentJson { get; init; }
+
+    [JsonPropertyName("measuredMcpTokens")]
+    public long? MeasuredMcpTokens { get; init; }
+
+    [JsonPropertyName("measuredBaselineTokens")]
+    public long? MeasuredBaselineTokens { get; init; }
+}
+
+/// <summary>
+/// Per-step token savings estimate.
+/// </summary>
+public sealed class TokenSavingsStepEstimate
+{
+    /// <summary>Model family that was used for tokenizer approximation in this step.</summary>
+    [JsonPropertyName("modelFamilyUsed")]
+    public ModelFamily ModelFamilyUsed { get; init; } = ModelFamily.Unknown;
+    [JsonPropertyName("stepId")]
+    public string StepId { get; init; } = string.Empty;
+
+    [JsonPropertyName("stepLabel")]
+    public string? StepLabel { get; init; }
+
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; init; }
+
+    [JsonPropertyName("mcpEstimatedTokens")]
+    public long McpEstimatedTokens { get; init; }
+
+    [JsonPropertyName("baselineEstimatedTokens")]
+    public long BaselineEstimatedTokens { get; init; }
+
+    [JsonPropertyName("estimatedSavingsTokens")]
+    public long EstimatedSavingsTokens { get; init; }
+
+    [JsonPropertyName("estimatedSavingsPercent")]
+    public double EstimatedSavingsPercent { get; init; }
+
+    [JsonPropertyName("confidence")]
+    public string Confidence { get; init; } = "low";
+
+    [JsonPropertyName("assumptionsProfile")]
+    public TokenSavingsAssumptionsProfile AssumptionsProfile { get; init; } = new();
+}
+
+/// <summary>
+/// Workflow-level token savings estimate with per-step detail.
+/// </summary>
+public sealed class TokenSavingsWorkflowEstimate
+{
+    /// <summary>Effective model family used for estimation (taken from steps; Unknown if mixed or unset).</summary>
+    [JsonPropertyName("modelFamilyUsed")]
+    public ModelFamily ModelFamilyUsed { get; init; } = ModelFamily.Unknown;
+    [JsonPropertyName("workflowId")]
+    public string WorkflowId { get; init; } = string.Empty;
+
+    [JsonPropertyName("mcpEstimatedTokens")]
+    public long McpEstimatedTokens { get; init; }
+
+    [JsonPropertyName("baselineEstimatedTokens")]
+    public long BaselineEstimatedTokens { get; init; }
+
+    [JsonPropertyName("estimatedSavingsTokens")]
+    public long EstimatedSavingsTokens { get; init; }
+
+    [JsonPropertyName("estimatedSavingsPercent")]
+    public double EstimatedSavingsPercent { get; init; }
+
+    [JsonPropertyName("confidence")]
+    public string Confidence { get; init; } = "low";
+
+    [JsonPropertyName("assumptionsProfile")]
+    public TokenSavingsAssumptionsProfile AssumptionsProfile { get; init; } = new();
+
+    [JsonPropertyName("steps")]
+    public TokenSavingsStepEstimate[] Steps { get; init; } = [];
+}

--- a/DotNetMcp/Telemetry/TokenSavingsModels.cs
+++ b/DotNetMcp/Telemetry/TokenSavingsModels.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.IO;
 
 namespace DotNetMcp;
 
@@ -171,7 +172,7 @@ public sealed class TokenSavingsAssumptionsProfile
             using var stream = assembly.GetManifestResourceStream(resourceName);
             if (stream != null)
             {
-                using var reader = new System.IO.StreamReader(stream);
+                using var reader = new StreamReader(stream);
                 var json = reader.ReadToEnd();
                 var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
                 var loaded = JsonSerializer.Deserialize<TokenSavingsAssumptionsProfile>(json, options);

--- a/DotNetMcp/Telemetry/TokenSavingsModels.cs
+++ b/DotNetMcp/Telemetry/TokenSavingsModels.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace DotNetMcp;
@@ -6,6 +8,7 @@ namespace DotNetMcp;
 /// The broad family of LLM a caller is using. Controls which tokenizer approximation
 /// and baseline scale factor are applied during token savings estimation.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ModelFamily
 {
     /// <summary>No model specified; uses the universal 4 chars/token fallback.</summary>
@@ -35,6 +38,7 @@ public enum ModelFamily
 /// <summary>
 /// Detected content kind used to pick the right chars-per-token ratio.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ContentKind
 {
     /// <summary>Plain English prose.</summary>
@@ -155,9 +159,35 @@ public sealed class TokenSavingsAssumptionsProfile
     public Dictionary<string, TokenSavingsWorkflowHeuristics> Workflows { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Creates the default v1 assumptions profile used by the estimator.
+    /// Creates the default v1 assumptions profile, loading it from the embedded JSON resource.
+    /// Falls back to hard-coded defaults if the resource cannot be read.
     /// </summary>
-    public static TokenSavingsAssumptionsProfile CreateDefault() => new()
+    public static TokenSavingsAssumptionsProfile CreateDefault()
+    {
+        try
+        {
+            var assembly = typeof(TokenSavingsAssumptionsProfile).Assembly;
+            const string resourceName = "DotNetMcp.Telemetry.Profiles.TokenSavingsProfile.Default.v1.json";
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            if (stream != null)
+            {
+                using var reader = new System.IO.StreamReader(stream);
+                var json = reader.ReadToEnd();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var loaded = JsonSerializer.Deserialize<TokenSavingsAssumptionsProfile>(json, options);
+                if (loaded is not null)
+                    return loaded;
+            }
+        }
+        catch (Exception)
+        {
+            // Fall through to hard-coded defaults
+        }
+
+        return CreateHardCodedDefault();
+    }
+
+    private static TokenSavingsAssumptionsProfile CreateHardCodedDefault() => new()
     {
         AssumptionsVersion = "v1",
         AssumptionsNotes = "Heuristic baseline profiles with a 4-char-per-token approximation for MCP payloads.",

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Core.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Core.cs
@@ -20,6 +20,8 @@ public sealed partial class DotNetCliTools
     private readonly ConcurrencyManager _concurrencyManager;
     private readonly ProcessSessionManager _processSessionManager;
     private readonly ToolMetricsAccumulator? _metricsAccumulator;
+    private readonly TokenSavingsAccumulator? _tokenSavingsAccumulator;
+    private readonly TokenSavingsEstimator? _tokenSavingsEstimator;
     private readonly ResourceSubscriptionManager? _subscriptions;
     private readonly IMcpTaskStore? _taskStore;
 
@@ -31,13 +33,23 @@ public sealed partial class DotNetCliTools
     private const int MaxSamplingPromptLength = 4000;
     private const int MaxSamplingResponseTokens = 256;
 
-    public DotNetCliTools(ILogger<DotNetCliTools> logger, ConcurrencyManager concurrencyManager, ProcessSessionManager processSessionManager, ToolMetricsAccumulator? metricsAccumulator = null, ResourceSubscriptionManager? subscriptions = null, IMcpTaskStore? taskStore = null)
+    public DotNetCliTools(
+        ILogger<DotNetCliTools> logger,
+        ConcurrencyManager concurrencyManager,
+        ProcessSessionManager processSessionManager,
+        ToolMetricsAccumulator? metricsAccumulator = null,
+        TokenSavingsAccumulator? tokenSavingsAccumulator = null,
+        TokenSavingsEstimator? tokenSavingsEstimator = null,
+        ResourceSubscriptionManager? subscriptions = null,
+        IMcpTaskStore? taskStore = null)
     {
         // DI guarantees logger is never null
         _logger = logger!;
         _concurrencyManager = concurrencyManager!;
         _processSessionManager = processSessionManager!;
         _metricsAccumulator = metricsAccumulator;
+        _tokenSavingsAccumulator = tokenSavingsAccumulator;
+        _tokenSavingsEstimator = tokenSavingsEstimator;
         _subscriptions = subscriptions;
         _taskStore = taskStore;
     }

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Metrics.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Metrics.cs
@@ -18,7 +18,7 @@ public sealed partial class DotNetCliTools
     /// No PII is stored; only tool names and timing data are tracked.
     /// </summary>
     /// <param name="action">The metrics operation to perform: Get (return current snapshot) or Reset (clear all counters)</param>
-    [McpServerTool(Title = "Server Metrics", ReadOnly = false, Idempotent = false, UseStructuredContent = true, OutputSchemaType = typeof(ServerMetricsResponse), IconSource = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Bar%20Chart/Flat/bar_chart_flat.svg")]
+    [McpServerTool(Title = "Server Metrics", ReadOnly = false, Idempotent = false, UseStructuredContent = true, IconSource = "https://raw.githubusercontent.com/microsoft/fluentui-emoji/62ecdc0d7ca5c6df32148c169556bc8d3782fca4/assets/Bar%20Chart/Flat/bar_chart_flat.svg")]
     [McpMeta("category", "telemetry")]
     [McpMeta("priority", 5.0)]
     [McpMeta("consolidatedTool", true)]

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Metrics.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Metrics.cs
@@ -22,10 +22,10 @@ public sealed partial class DotNetCliTools
     [McpMeta("category", "telemetry")]
     [McpMeta("priority", 5.0)]
     [McpMeta("consolidatedTool", true)]
-    [McpMeta("actions", JsonValue = """["Get","Reset"]""")]
+    [McpMeta("actions", JsonValue = """["Get","TokenSavingsGet","TokenSavingsReset","Reset"]""")]
     public partial Task<CallToolResult> DotnetServerMetrics(DotnetServerMetricsAction action)
     {
-        if (_metricsAccumulator is null)
+        if ((_metricsAccumulator is null) && action is DotnetServerMetricsAction.Get or DotnetServerMetricsAction.Reset)
         {
             var error = ErrorResultFactory.ReturnCapabilityNotAvailable(
                 "server metrics",
@@ -34,21 +34,55 @@ public sealed partial class DotNetCliTools
             return Task.FromResult(StructuredContentHelper.ToCallToolResult(ErrorResultFactory.ToJson(error)));
         }
 
+        if ((_tokenSavingsAccumulator is null || _tokenSavingsEstimator is null) && action is DotnetServerMetricsAction.TokenSavingsGet or DotnetServerMetricsAction.TokenSavingsReset)
+        {
+            var error = ErrorResultFactory.ReturnCapabilityNotAvailable(
+                "token savings metrics",
+                "Token savings services are not registered. Ensure TokenSavingsAccumulator and TokenSavingsEstimator are registered in the DI container.",
+                alternatives: null);
+            return Task.FromResult(StructuredContentHelper.ToCallToolResult(ErrorResultFactory.ToJson(error)));
+        }
+
         switch (action)
         {
             case DotnetServerMetricsAction.Reset:
-                _metricsAccumulator.Reset();
+                _metricsAccumulator!.Reset();
                 var resetResponse = new ServerMetricsResetResponse
                 {
                     Success = true,
                     Message = "Server metrics have been reset."
                 };
-                var resetJson = ErrorResultFactory.ToJson(resetResponse);
-                return Task.FromResult(StructuredContentHelper.ToCallToolResult(resetJson, resetResponse));
+                return Task.FromResult(StructuredContentHelper.ToCallToolResult(ErrorResultFactory.ToJson(resetResponse), resetResponse));
+
+            case DotnetServerMetricsAction.TokenSavingsReset:
+                _tokenSavingsAccumulator!.Reset();
+                var tokenResetResponse = new ServerMetricsTokenSavingsResponse
+                {
+                    Success = true,
+                    Message = "Token savings estimates have been reset."
+                };
+                return Task.FromResult(StructuredContentHelper.ToCallToolResult(ErrorResultFactory.ToJson(tokenResetResponse), tokenResetResponse));
+
+            case DotnetServerMetricsAction.TokenSavingsGet:
+                var tokenSnapshot = _tokenSavingsAccumulator!.GetSnapshot();
+                var tokenResponse = new ServerMetricsTokenSavingsResponse
+                {
+                    Success = true,
+                    Message = "Token savings estimates retrieved.",
+                    WorkflowTokenSavings = tokenSnapshot
+                        .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                        .Select(kv => kv.Value)
+                        .ToArray(),
+                    TotalWorkflowSavingsTokens = tokenSnapshot.Values.Sum(item => item.EstimatedSavingsTokens),
+                    TotalWorkflowMcpTokens = tokenSnapshot.Values.Sum(item => item.McpEstimatedTokens),
+                    TotalWorkflowBaselineTokens = tokenSnapshot.Values.Sum(item => item.BaselineEstimatedTokens),
+                    AssumptionsVersion = tokenSnapshot.Values.Select(item => item.AssumptionsProfile.AssumptionsVersion).FirstOrDefault() ?? "v1"
+                };
+                return Task.FromResult(StructuredContentHelper.ToCallToolResult(ErrorResultFactory.ToJson(tokenResponse), tokenResponse));
 
             case DotnetServerMetricsAction.Get:
             default:
-                var snapshot = _metricsAccumulator.GetSnapshot();
+                var snapshot = _metricsAccumulator!.GetSnapshot();
                 var metricsResponse = new ServerMetricsResponse
                 {
                     ToolMetrics = snapshot
@@ -56,10 +90,10 @@ public sealed partial class DotNetCliTools
                         .ToDictionary(kv => kv.Key, kv => kv.Value),
                     TotalInvocations = snapshot.Values.Sum(m => m.InvocationCount),
                     TotalSuccesses = snapshot.Values.Sum(m => m.SuccessCount),
-                    TotalFailures = snapshot.Values.Sum(m => m.FailureCount)
+                    TotalFailures = snapshot.Values.Sum(m => m.FailureCount),
+                    TokenSavingsEnabled = _tokenSavingsAccumulator is not null && _tokenSavingsEstimator is not null
                 };
-                var json = ErrorResultFactory.ToJson(metricsResponse);
-                return Task.FromResult(StructuredContentHelper.ToCallToolResult(json, metricsResponse));
+                return Task.FromResult(StructuredContentHelper.ToCallToolResult(ErrorResultFactory.ToJson(metricsResponse), metricsResponse));
         }
     }
 }
@@ -98,4 +132,42 @@ public sealed class ServerMetricsResponse
     /// <summary>Total failed invocations across all tools since last reset.</summary>
     [JsonPropertyName("totalFailures")]
     public long TotalFailures { get; init; }
+
+    /// <summary>Whether token savings reporting is available on this server instance.</summary>
+    [JsonPropertyName("tokenSavingsEnabled")]
+    public bool TokenSavingsEnabled { get; init; }
+}
+
+/// <summary>
+/// JSON response for token savings metric operations.
+/// </summary>
+public sealed class ServerMetricsTokenSavingsResponse
+{
+    /// <summary>Indicates whether the operation was successful.</summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    /// <summary>Human-readable confirmation or summary message.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>Workflow estimates currently stored in the accumulator.</summary>
+    [JsonPropertyName("workflowTokenSavings")]
+    public TokenSavingsWorkflowEstimate[] WorkflowTokenSavings { get; init; } = [];
+
+    /// <summary>Total estimated workflow token savings across the snapshot.</summary>
+    [JsonPropertyName("totalWorkflowSavingsTokens")]
+    public long TotalWorkflowSavingsTokens { get; init; }
+
+    /// <summary>Total estimated MCP-side workflow tokens across the snapshot.</summary>
+    [JsonPropertyName("totalWorkflowMcpTokens")]
+    public long TotalWorkflowMcpTokens { get; init; }
+
+    /// <summary>Total estimated baseline workflow tokens across the snapshot.</summary>
+    [JsonPropertyName("totalWorkflowBaselineTokens")]
+    public long TotalWorkflowBaselineTokens { get; init; }
+
+    /// <summary>Assumptions profile version used by the snapshot.</summary>
+    [JsonPropertyName("assumptionsVersion")]
+    public string AssumptionsVersion { get; init; } = "v1";
 }

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Misc.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Misc.cs
@@ -79,7 +79,7 @@ public sealed partial class DotNetCliTools
                 Completions = true,  // Argument autocomplete: template names, framework TFMs, configurations, runtime identifiers
                 Sampling = true,     // Sampling for AI-assisted build/test error interpretation (when client supports it)
                 ProgressNotifications = true, // Real-time progress updates for build, test, publish, and other long-running operations
-                TokenSavings = true // Workflow-level token savings reporting is available
+                TokenSavings = _tokenSavingsAccumulator is not null && _tokenSavingsEstimator is not null // Derived from DI: true when TokenSavingsAccumulator and TokenSavingsEstimator are registered
             },
             SdkVersions = new SdkVersionInfo
             {

--- a/DotNetMcp/Tools/Cli/DotNetCliTools.Misc.cs
+++ b/DotNetMcp/Tools/Cli/DotNetCliTools.Misc.cs
@@ -77,7 +77,8 @@ public sealed partial class DotNetCliTools
                 McpLogging = true,   // MCP log notifications sent to client during key operations (build, test, publish, restore, package add/update)
                 Completions = true,  // Argument autocomplete: template names, framework TFMs, configurations, runtime identifiers
                 Sampling = true,     // Sampling for AI-assisted build/test error interpretation (when client supports it)
-                ProgressNotifications = true // Real-time progress updates for build, test, publish, and other long-running operations
+                ProgressNotifications = true, // Real-time progress updates for build, test, publish, and other long-running operations
+                TokenSavings = true // Workflow-level token savings reporting is available
             },
             SdkVersions = new SdkVersionInfo
             {
@@ -116,6 +117,7 @@ public sealed partial class DotNetCliTools
         result.AppendLine("  • Elicitation support: confirmation dialogs for destructive operations (Clean, solution Remove)");
         result.AppendLine("  • MCP logging notifications: informational messages sent to the client during key operations (build, test, publish, restore, package add/update)");
         result.AppendLine("  • Telemetry: in-memory metrics collected via MCP message filter (dotnet_server_metrics)");
+        result.AppendLine("  • Token savings reporting: workflow-level MCP vs baseline estimates with confidence and assumptions metadata");
         result.AppendLine("  • Direct .NET SDK integration via NuGet packages");
         result.AppendLine("  • Template Engine integration with caching (5-min TTL)");
         result.AppendLine("  • Framework validation and LTS identification");

--- a/doc/machine-readable-contract.md
+++ b/doc/machine-readable-contract.md
@@ -218,6 +218,53 @@ interface MinimalMutatingResult {
 
 ### Examples
 
+---
+
+## Token Savings Estimation Contract
+
+The `dotnet_server_metrics` tool can also return workflow-level token savings estimates. These estimates are intended for observability and comparative analysis only.
+
+### Output Shape
+
+Token savings responses include:
+
+- `workflowId`
+- `mcpEstimatedTokens`
+- `baselineEstimatedTokens`
+- `estimatedSavingsTokens`
+- `estimatedSavingsPercent`
+- `confidence`
+- `assumptionsProfile`
+- `steps[]`
+
+### Estimation Formula
+
+MCP token usage is approximated from payload size:
+
+$$
+	ext{mcpEstimatedTokens} \approx \lceil \frac{\text{chars}}{4} \rceil
+$$
+
+Savings are then computed as:
+
+$$
+	ext{estimatedSavingsTokens} = \text{baselineEstimatedTokens} - \text{mcpEstimatedTokens}
+$$
+
+$$
+	ext{estimatedSavingsPercent} = \frac{\text{estimatedSavingsTokens}}{\text{baselineEstimatedTokens}} \times 100
+$$
+
+### Confidence
+
+- `high`: measured MCP and baseline values are available
+- `medium`: measured and heuristic inputs are mixed
+- `low`: heuristic-only estimate
+
+### Versioning
+
+Assumptions are versioned. The initial profile is `v1` and includes workflow heuristics for project creation, test-failure summarization, and web API + EF setup workflows.
+
 #### Build Success
 
 ```json

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -258,6 +258,31 @@ Failed requests are automatically logged with:
 - Error type and message
 - Request duration
 - Tool/resource name
+
+## Token Savings Estimation
+
+dotnet-mcp also exposes an opt-in workflow-level token savings estimator through the server metrics surface. This feature does not report exact billable token counts. Instead, it provides a transparent estimate that compares:
+
+- MCP-side payload size using a documented approximation of `chars / 4`
+- A baseline non-MCP workflow built from versioned heuristics
+
+The initial assumptions profile is versioned as `v1` and is designed to be easy to inspect and tune. It includes workflow heuristics for:
+
+- `create-project-package-build`
+- `run-tests-summarize-failures`
+- `scaffold-webapi-ef-setup`
+
+### Confidence Levels
+
+- `high` when measured MCP and baseline values are available
+- `medium` when measured and heuristic values are mixed
+- `low` when the estimate is heuristic-only
+
+### Caveats
+
+- Estimates are intentionally lightweight and reproducible, not billing-accurate.
+- Baseline heuristics are transparent and may evolve as more workflow data is collected.
+- Workflow summaries are keyed by explicit `workflowId` values to keep rollups deterministic.
 - Stack trace (in debug mode)
 
 ## Monitoring Best Practices

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -258,6 +258,7 @@ Failed requests are automatically logged with:
 - Error type and message
 - Request duration
 - Tool/resource name
+- Stack trace (in debug mode)
 
 ## Token Savings Estimation
 
@@ -283,7 +284,7 @@ The initial assumptions profile is versioned as `v1` and is designed to be easy 
 - Estimates are intentionally lightweight and reproducible, not billing-accurate.
 - Baseline heuristics are transparent and may evolve as more workflow data is collected.
 - Workflow summaries are keyed by explicit `workflowId` values to keep rollups deterministic.
-- Stack trace (in debug mode)
+- The `tokenSavings` capability flag and `dotnet_server_metrics (TokenSavingsGet)` surface are available once `TokenSavingsAccumulator` and `TokenSavingsEstimator` are registered in DI. The accumulator is populated only when callers explicitly invoke `RecordWorkflow`; no automatic recording at the tool-call boundary is performed in this release.
 
 ## Monitoring Best Practices
 


### PR DESCRIPTION
## Summary

Implements workflow-level token savings estimation, comparing MCP-assisted vs non-MCP baseline token usage. This gives AI assistants (and users) visibility into how much token overhead the MCP server saves by providing structured, targeted tool responses instead of raw CLI output.

## What's included

### Core types (`TokenSavingsModels.cs`)
- `TokenSavingsStepInput` / `TokenSavingsStepEstimate` / `TokenSavingsWorkflowEstimate` — full estimation schema
- `ModelFamily` enum (GPT-4, GPT-4o, O1, Claude Sonnet/Opus/Haiku, Gemini Pro/Flash, Llama 3, Mistral)
- `ContentKind` enum (Prose, JSON, Code) with automatic detection
- `TokenizerApproximation` with per-model char-to-token ratios and baseline scale factors

### Estimator (`TokenSavingsEstimator.cs`)
- Versioned assumptions profiles loaded from embedded JSON
- Model-family-aware token estimation (step → workflow → constructor default fallback)
- Content-kind detection for accurate char-to-token conversion
- Baseline overhead heuristics with model-specific scaling

### Accumulator (`TokenSavingsAccumulator.cs`)
- Thread-safe `ConcurrentDictionary`-based session tracking
- `RecordWorkflow`, `GetSnapshot`, `Reset`

### Integration
- DI singleton registration in `Program.cs`
- `TokenSavingsGet` / `TokenSavingsReset` actions in `DotnetActions.cs`
- Server capabilities advertisement
- Wired into `DotNetCliTools.Metrics.cs` for server metrics exposure

### Tests (15 test cases)
- Rollup math and step aggregation
- Profile versioning fallback
- Measured vs estimated token selection
- Model-family propagation and per-step overrides
- Cross-model baseline divergence
- Content-kind detection (6 cases)
- Model ID parsing

### Documentation
- `doc/telemetry.md` — methodology and assumptions
- `doc/machine-readable-contract.md` — contract additions

## Follow-up

- #462 — A/B testing validation to compare heuristic estimates against real tokenizer counts

Closes #452