### PR TITLE
Fix ServerCapabilities token savings test fixture wiring

### DIFF
--- a/DotNetMcp.Tests/Server/ServerCapabilitiesTests.cs
+++ b/DotNetMcp.Tests/Server/ServerCapabilitiesTests.cs
@@ -17,7 +17,13 @@ public class ServerCapabilitiesTests
     {
         _logger = NullLogger<DotNetCliTools>.Instance;
         _concurrencyManager = new ConcurrencyManager();
-        _tools = new DotNetCliTools(_logger, _concurrencyManager, new ProcessSessionManager(), taskStore: new InMemoryMcpTaskStore());
+        _tools = new DotNetCliTools(
+            _logger,
+            _concurrencyManager,
+            new ProcessSessionManager(),
+            tokenSavingsAccumulator: new TokenSavingsAccumulator(),
+            tokenSavingsEstimator: new TokenSavingsEstimator(),
+            taskStore: new InMemoryMcpTaskStore());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update `ServerCapabilitiesTests` fixture to construct `DotNetCliTools` with token savings dependencies
- align test setup with `DotnetServerCapabilities` behavior where `supports.tokenSavings` is DI-derived

## Why
`DotnetServerCapabilities_Supports_TokenSavings_IsTrue` was failing because the test instantiated `DotNetCliTools` without `TokenSavingsAccumulator` and `TokenSavingsEstimator`, resulting in `supports.tokenSavings = false`.

## Validation
- `dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj -- --filter-method "DotNetMcp.Tests.ServerCapabilitiesTests.DotnetServerCapabilities_Supports_TokenSavings_IsTrue"`
- `dotnet test --project DotNetMcp.Tests/DotNetMcp.Tests.csproj -- --filter-class "DotNetMcp.Tests.ServerCapabilitiesTests"`