### PR TITLE
chore: update dependabot configuration to monitor multiple NuGet directories and add GitHub Actions group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,24 @@
 
 version: 2
 updates:
-  # Monitor NuGet dependencies in the DotNetMcp project
+  # Monitor NuGet dependencies in the main and test projects
   - package-ecosystem: "nuget"
-    directory: "/DotNetMcp"
+    directories:
+      - "/DotNetMcp"
+      - "/DotNetMcp.Tests"
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      microsoft-dotnet-dependencies:
+        patterns:
+          - "Microsoft.*"
+      mcp-sdk-dependencies:
+        patterns:
+          - "ModelContextProtocol"
+      test-dependencies:
+        patterns:
+          - "xunit.*"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -16,13 +28,17 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    
+
   # Monitor GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to improve dependency management for both the main and test projects. The changes expand monitoring coverage and introduce new grouping strategies for dependencies, making it easier to manage and review updates.

**Dependabot configuration improvements:**

* Added monitoring for NuGet dependencies in both `/DotNetMcp` and `/DotNetMcp.Tests` directories, instead of only `/DotNetMcp`.
* Introduced groups for NuGet dependencies, organizing updates by Microsoft dependencies, MCP SDK dependencies, and test dependencies (e.g., `xunit`).
* Added a group for GitHub Actions dependencies, grouping all action updates together.